### PR TITLE
Adjusting parsing and test cases for Year and YearMonth

### DIFF
--- a/zio-cli/shared/src/test/scala/zio/cli/PrimTypeSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/PrimTypeSpec.scala
@@ -11,128 +11,116 @@ import java.time.MonthDay
 import java.time.Year
 import java.time.YearMonth
 
-object PrimTypeSpec extends DefaultRunnableSpec
-{
-  def spec = suite("PrimTypeTests") (
+object PrimTypeSpec extends DefaultRunnableSpec {
+  def spec = suite("PrimTypeTests")(
     suite("Text Suite") {
       testM("validates everything") {
-        checkM(Gen.anyString) {i => 
+        checkM(Gen.anyString) { i =>
           assertM(PrimType.Text.validate(i))(equalTo(i))
         }
       }
     },
-    
     suite("Decimal Suite") {
       testM("validate returns proper BigDecimal representation") {
-        checkM(Gen.bigDecimal(BigDecimal("1.41421356237309504880168"), BigDecimal("50.4"))) {i => 
+        checkM(Gen.bigDecimal(BigDecimal("1.41421356237309504880168"), BigDecimal("50.4"))) { i =>
           assertM(PrimType.Decimal.validate(i.toString()))(equalTo(i))
         }
       }
     },
-
     suite("Integer Suite") {
       testM("validate returns proper BigInt representation") {
-        checkM(anyBigIntString) {i => 
+        checkM(anyBigIntString) { i =>
           assertM(PrimType.Integer.validate(i.toString()))(equalTo(BigInt(i)))
         }
       }
-    },    
-
+    },
     suite("Boolean Suite") {
       testM("validate true cominations returns proper Boolean representation") {
-        checkM(anyTrueBooleanString) {i => 
+        checkM(anyTrueBooleanString) { i =>
           assertM(PrimType.Boolean.validate(i))(equalTo(true))
         }
       };
       testM("validate false combinations returns proper Boolean representation") {
-        checkM(anyFalseBooleanString) {i => 
+        checkM(anyFalseBooleanString) { i =>
           assertM(PrimType.Boolean.validate(i))(equalTo(false))
         }
       }
     },
-
     suite("Instant Suite") {
       testM("validate returns proper Instant representation") {
-        checkM(Gen.anyInstant) {i => 
+        checkM(Gen.anyInstant) { i =>
           assertM(PrimType.Instant.validate(i.toString()))(equalTo(i))
-        } 
+        }
       }
     },
-
     suite("LocalDateTime Suite") {
       testM("validate returns proper LocalDateTime representation") {
-        checkM(anyLocalDateTime) {i => 
+        checkM(anyLocalDateTime) { i =>
           assertM(PrimType.LocalDateTime.validate(i))(equalTo(LocalDateTime.parse(i)))
         }
       }
     },
-
     suite("LocalDate Suite") {
       testM("validate returns proper LocalDate representation") {
-        checkM(anyLocalDate) {i => 
+        checkM(anyLocalDate) { i =>
           assertM(PrimType.LocalDate.validate(i))(equalTo(LocalDate.parse(i)))
         }
       }
     },
-
     suite("LocalTime Suite") {
       testM("validate returns proper LocalTime representation") {
-        checkM(anyLocalTime) {i => 
+        checkM(anyLocalTime) { i =>
           assertM(PrimType.LocalTime.validate(i))(equalTo(LocalTime.parse(i)))
         }
       }
     },
-
     suite("MonthDay Suite") {
       testM("validate returns proper MonthDay representation") {
-        checkM(anyMonthDay) {i => 
+        checkM(anyMonthDay) { i =>
           assertM(PrimType.MonthDay.validate(i))(equalTo(MonthDay.parse(i)))
         }
       }
     },
-
     suite("OffsetDateTime Suite") {
       testM("validate returns proper OffsetDateTime representation") {
-        checkM(Gen.anyOffsetDateTime) {i => 
+        checkM(Gen.anyOffsetDateTime) { i =>
           assertM(PrimType.OffsetDateTime.validate(i.toString))(equalTo(i))
         }
       }
     },
-
     suite("OffsetTime Suite") {
       testM("validate returns proper OffsetTime representation") {
-        checkM(Gen.anyOffsetDateTime.map(_.toOffsetTime)) {i => 
+        checkM(Gen.anyOffsetDateTime.map(_.toOffsetTime)) { i =>
           assertM(PrimType.OffsetTime.validate(i.toString))(equalTo(i))
         }
       }
-    }, 
-
+    },
     suite("Year Suite") {
       testM("validate returns proper Year representation") {
-        checkM(anyYear) {i => 
-          assertM(PrimType.Year.validate(i))(equalTo(Year.parse(i)))
+        checkM(anyYear) { i =>
+          assertM(PrimType.Year.validate(i.toString))(equalTo(i))
         }
       }
-    }, 
-
+    },
     suite("YearMonth Suite") {
       testM("validate returns proper YearMonth representation") {
-        checkM(anyYearMonth) {i => 
-          assertM(PrimType.YearMonth.validate(i))(equalTo(YearMonth.parse(i)))
+        checkM(anyYearMonth) { i =>
+          assertM(PrimType.YearMonth.validate(i.toString))(equalTo(i))
         }
       }
-    }, 
+    }
   )
 
-  val anyBigIntString = Gen.long(0, Long.MaxValue).map(BigInt(_)).map(_.toString)
-  val anyTrueBooleanString: Gen[Any, String] = Gen.fromIterable(List("true", "TruE", "1", "y", "yes", "yEs",  "on"))
-  val anyFalseBooleanString: Gen[Any, String] = Gen.fromIterable(List("false", "FAlSE", "0", "n", "no", "off", "OFF" ))
+  val anyBigIntString                         = Gen.long(0, Long.MaxValue).map(BigInt(_)).map(_.toString)
+  val anyTrueBooleanString: Gen[Any, String]  = Gen.fromIterable(List("true", "TruE", "1", "y", "yes", "yEs", "on"))
+  val anyFalseBooleanString: Gen[Any, String] = Gen.fromIterable(List("false", "FAlSE", "0", "n", "no", "off", "OFF"))
 
-  val anyLocalDateTime = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC).toLocalDateTime.toString)
-  val anyLocalDate = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC).toLocalDate.toString)
-  val anyLocalTime = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC).toLocalTime.toString) 
-  val anyMonthDay = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC)).map(d => MonthDay.of(d.getMonthValue, d.getDayOfMonth).toString) 
-  val anyYear = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC).getYear.toString) 
-  val anyYearMonth = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC)).map(d => YearMonth.of(d.getYear, d.getMonthValue).toString) 
+  val anyInstant       = Gen.anyInstant.map(_.atZone(ZoneOffset.UTC))
+  val anyLocalDateTime = anyInstant.map(_.toLocalDateTime.toString)
+  val anyLocalDate     = anyInstant.map(_.toLocalDate.toString)
+  val anyLocalTime     = anyInstant.map(_.toLocalTime.toString)
+  val anyMonthDay      = anyInstant.map(d => MonthDay.of(d.getMonthValue, d.getDayOfMonth).toString)
+  val anyYear          = Gen.int(Year.MIN_VALUE, Year.MAX_VALUE).map(Year.of)
+  val anyYearMonth     = anyYear.map(d => YearMonth.of(d.getValue(), 2))
 
 }


### PR DESCRIPTION
I adjusted the parsing on edge cases, where Year and YearMonth toString representation is not valid in certain `parse` cases which needs `-` or `+` prefix in some cases.
This also fixes test suite which failed on PrimTypes Year and YearMonth, which i wasn't able to wrap on time before previous merge. 