### PR TITLE
Get rid of all instances of List[HelpDoc].

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Args.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Args.scala
@@ -59,7 +59,7 @@ sealed trait Args[+A] { self =>
 
   def synopsis: UsageSynopsis
 
-  def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], A)]
+  def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], A)]
 }
 
 object Args {
@@ -83,10 +83,10 @@ object Args {
 
     def synopsis: UsageSynopsis = UsageSynopsis.Named(name, primType.choices)
 
-    def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], A)] =
+    def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], A)] =
       args match {
-        case head :: tail => primType.validate(Some(head), opts).bimap(text => HelpDoc.p(text) :: Nil, a => tail -> a)
-        case Nil          => IO.fail(HelpDoc.p(s"Missing argument <${pseudoName}> with values ${primType.choices}.") :: Nil)
+        case head :: tail => primType.validate(Some(head), opts).bimap(text => HelpDoc.p(text), a => tail -> a)
+        case Nil          => IO.fail(HelpDoc.p(s"Missing argument <${pseudoName}> with values ${primType.choices}."))
       }
 
     private def name: String = "<" + pseudoName.getOrElse(primType.typeName) + ">"
@@ -103,7 +103,7 @@ object Args {
 
     def synopsis: UsageSynopsis = UsageSynopsis.None
 
-    def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], Unit)] =
+    def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], Unit)] =
       IO.succeed((args, ()))
   }
 
@@ -118,7 +118,7 @@ object Args {
 
     def synopsis: UsageSynopsis = head.synopsis + tail.synopsis
 
-    def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], (A, B))] =
+    def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], (A, B))] =
       for {
         tuple     <- head.validate(args, opts)
         (args, a) = tuple
@@ -153,11 +153,11 @@ object Args {
 
     def minSize: Int = min.getOrElse(0) * value.minSize
 
-    def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], List[A])] = {
+    def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], List[A])] = {
       val min1 = min.getOrElse(0)
       val max1 = max.getOrElse(Int.MaxValue)
 
-      def loop(args: List[String], acc: List[A]): IO[List[HelpDoc], (List[String], List[A])] =
+      def loop(args: List[String], acc: List[A]): IO[HelpDoc, (List[String], List[A])] =
         if (acc.length >= max1) IO.succeed(args -> acc)
         else
           value
@@ -182,11 +182,11 @@ object Args {
 
     def synopsis: UsageSynopsis = value.synopsis
 
-    def validate(args: List[String], opts: ParserOptions): IO[List[HelpDoc], (List[String], B)] =
+    def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], B)] =
       value.validate(args, opts).flatMap {
         case (r, a) =>
           f(a) match {
-            case Left(value)  => IO.fail(List(value))
+            case Left(value)  => IO.fail(value)
             case Right(value) => IO.succeed((r, value))
           }
       }

--- a/zio-cli/shared/src/main/scala/zio/cli/HelpDoc.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/HelpDoc.scala
@@ -29,7 +29,6 @@ sealed trait HelpDoc { self =>
       case HelpDoc.Empty                 => true
       case HelpDoc.DescriptionList(xs)   => true
       case HelpDoc.Sequence(left, right) => left.isDescriptionList
-      case HelpDoc.Enumeration(xs)       => false
       case _                             => false
     }
 
@@ -52,7 +51,6 @@ sealed trait HelpDoc { self =>
       case HelpDoc.Empty                 => true
       case HelpDoc.DescriptionList(xs)   => xs.forall(_._2.isEmpty)
       case HelpDoc.Sequence(left, right) => left.isEmpty && right.isEmpty
-      case HelpDoc.Enumeration(xs)       => xs.forall(_.isEmpty)
       case _                             => false
     }
 
@@ -82,9 +80,6 @@ sealed trait HelpDoc { self =>
     def currentStyle(): String = styles.headOption.getOrElse(Console.RESET)
 
     def resetStyle(): Unit = styles = styles.drop(1)
-
-    def renderText(text: String): Unit =
-      renderSpan(Span.text(text))
 
     def renderNewline(): Unit =
       if (printedSep < 2) {
@@ -120,16 +115,6 @@ sealed trait HelpDoc { self =>
               resetStyle()
               renderNewline()
               writer.indent(4)
-              renderHelpDoc(helpDoc)
-              writer.unindent()
-              renderNewline()
-          }
-
-        case HelpDoc.Enumeration(elements) =>
-          elements.zipWithIndex.foreach {
-            case (helpDoc, index) =>
-              writer.indent(2)
-              renderText("- ")
               renderHelpDoc(helpDoc)
               writer.unindent()
               renderNewline()
@@ -193,7 +178,6 @@ object HelpDoc {
   final case class Header(value: Span, level: Int)                     extends HelpDoc
   final case class Paragraph(value: Span)                              extends HelpDoc
   final case class DescriptionList(definitions: List[(Span, HelpDoc)]) extends HelpDoc
-  final case class Enumeration(elements: List[HelpDoc])                extends HelpDoc
   final case class Sequence(left: HelpDoc, right: HelpDoc)             extends HelpDoc
 
   def blocks(bs: Iterable[HelpDoc]): HelpDoc =
@@ -205,8 +189,6 @@ object HelpDoc {
   def descriptionList(definitions: (Span, HelpDoc)*): HelpDoc = HelpDoc.DescriptionList(definitions.toList)
 
   val empty: HelpDoc = Empty
-
-  def enumeration(elements: HelpDoc*): HelpDoc = HelpDoc.Enumeration(elements.toList)
 
   def h1(t: String): HelpDoc  = h1(Span.text(t))
   def h1(span: Span): HelpDoc = HelpDoc.Header(span, 1)

--- a/zio-cli/shared/src/main/scala/zio/cli/HelpDoc.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/HelpDoc.scala
@@ -29,6 +29,7 @@ sealed trait HelpDoc { self =>
       case HelpDoc.Empty                 => true
       case HelpDoc.DescriptionList(xs)   => true
       case HelpDoc.Sequence(left, right) => left.isDescriptionList
+      case HelpDoc.Enumeration(xs)       => false
       case _                             => false
     }
 
@@ -51,6 +52,7 @@ sealed trait HelpDoc { self =>
       case HelpDoc.Empty                 => true
       case HelpDoc.DescriptionList(xs)   => xs.forall(_._2.isEmpty)
       case HelpDoc.Sequence(left, right) => left.isEmpty && right.isEmpty
+      case HelpDoc.Enumeration(xs)       => xs.forall(_.isEmpty)
       case _                             => false
     }
 
@@ -80,6 +82,9 @@ sealed trait HelpDoc { self =>
     def currentStyle(): String = styles.headOption.getOrElse(Console.RESET)
 
     def resetStyle(): Unit = styles = styles.drop(1)
+
+    def renderText(text: String): Unit =
+      renderSpan(Span.text(text))
 
     def renderNewline(): Unit =
       if (printedSep < 2) {
@@ -115,6 +120,16 @@ sealed trait HelpDoc { self =>
               resetStyle()
               renderNewline()
               writer.indent(4)
+              renderHelpDoc(helpDoc)
+              writer.unindent()
+              renderNewline()
+          }
+
+        case HelpDoc.Enumeration(elements) =>
+          elements.zipWithIndex.foreach {
+            case (helpDoc, index) =>
+              writer.indent(2)
+              renderText("- ")
               renderHelpDoc(helpDoc)
               writer.unindent()
               renderNewline()
@@ -178,6 +193,7 @@ object HelpDoc {
   final case class Header(value: Span, level: Int)                     extends HelpDoc
   final case class Paragraph(value: Span)                              extends HelpDoc
   final case class DescriptionList(definitions: List[(Span, HelpDoc)]) extends HelpDoc
+  final case class Enumeration(elements: List[HelpDoc])                extends HelpDoc
   final case class Sequence(left: HelpDoc, right: HelpDoc)             extends HelpDoc
 
   def blocks(bs: Iterable[HelpDoc]): HelpDoc =
@@ -189,6 +205,8 @@ object HelpDoc {
   def descriptionList(definitions: (Span, HelpDoc)*): HelpDoc = HelpDoc.DescriptionList(definitions.toList)
 
   val empty: HelpDoc = Empty
+
+  def enumeration(elements: HelpDoc*): HelpDoc = HelpDoc.Enumeration(elements.toList)
 
   def h1(t: String): HelpDoc  = h1(Span.text(t))
   def h1(span: Span): HelpDoc = HelpDoc.Header(span, 1)


### PR DESCRIPTION
### Overview

zio-cli used to use a `List[HelpDoc]` as the error type when validating input arguments to represent multiple help docs to display to the user. This is no longer required because of the `HelpDoc.Sequence` type, which allows joining two `HelpDoc`s together. This change gets rid of all instances of `List[HelpDoc]` and replaces them with `HelpDoc`.

## Summary of Changes

1. Find and replace all instances of `List[HelpDoc]` with `HelpDoc`
2. Get rid of all cons operations in validate methods

## Notes

1. The only time the master code created `List[HelpDoc]` was with a cons operation to `Nil`, which means we were never returning more than one `HelpDoc` in the error channel
2. The only references to `HelpDoc.Sequence` in the code are in pattern matches, which means we never any instances of this value for now
