### PR TITLE
Fix bool options bug

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -193,11 +193,14 @@ object Options {
     def validate(args: List[String], opts: ParserOptions): IO[HelpDoc, (List[String], A)] =
       args match {
         case head :: tail if supports(head, opts) =>
-          (tail match {
-            case Nil         => primType.validate(None, opts)
-            case ::(head, _) => primType.validate(Some(head), opts)
-          }).bimap(f => p(f), a => tail.drop(1) -> a)
-
+          primType match {
+            case _: PrimType.Bool => primType.validate(None, opts).bimap(f => p(f), tail -> _)
+            case _ =>
+              (tail match {
+                case Nil         => primType.validate(None, opts)
+                case ::(head, _) => primType.validate(Some(head), opts)
+              }).bimap(f => p(f), a => tail.drop(1) -> a)
+          }
         case head :: tail =>
           validate(tail, opts).map {
             case (args, a) => (head :: args, a)

--- a/zio-cli/shared/src/test/scala/zio/cli/ArgsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/ArgsSpec.scala
@@ -1,0 +1,23 @@
+package zio.cli
+
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, suite, testM, DefaultRunnableSpec }
+
+object ArgsSpec extends DefaultRunnableSpec {
+
+  def spec = suite("Args Suite")(
+    testM("validate boolean arguments") {
+      val a = Args.bool("boolArg1") ++ Args.bool("boolArg2").repeat
+
+      for {
+        v1 <- a.validate("yes" :: Nil, ParserOptions.default)
+        v2 <- a.validate("yes" :: "yes" :: Nil, ParserOptions.default)
+        v3 <- a.validate("yes" :: "no" :: "yes" :: Nil, ParserOptions.default)
+      } yield {
+        assert(v1)(equalTo(List.empty[String] -> (true -> List.empty[Boolean])) ?? "v2") &&
+        assert(v2)(equalTo(List.empty[String] -> (true -> List(true))) ?? "v3") &&
+        assert(v3)(equalTo(List.empty[String] -> (true -> List(false, true))) ?? "v3")
+      }
+    }
+  )
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -19,17 +19,18 @@ object OptionsSpec extends DefaultRunnableSpec {
 
       assertM(r)(equalTo(List() -> true))
     },
-    testM("validate boolean option with and without value") {
-      val o = Options.bool("help", true)
+    testM("validate boolean option with followup option") {
+      val o = Options.bool("help", true) :: Options.bool("v", true)
 
       for {
         v1 <- o.validate(Nil, ParserOptions.default)
         v2 <- o.validate("--help" :: Nil, ParserOptions.default)
-        v3 <- o.validate("--help" :: "on" :: Nil, ParserOptions.default)
-      } yield assert(v1)(equalTo(Nil          -> false)) &&
-        assert(v2)(equalTo(List.empty[String] -> true) ?? "v2") && assert(v3)(
-        equalTo(List.empty[String]            -> true) ?? "v3"
-      )
+        v3 <- o.validate("--help" :: "-v" :: Nil, ParserOptions.default)
+      } yield {
+        assert(v1)(equalTo(Nil                -> (false -> false))) &&
+        assert(v2)(equalTo(List.empty[String] -> (true  -> false)) ?? "v2") &&
+        assert(v3)(equalTo(List.empty[String] -> (true  -> true)) ?? "v3")
+      }
     },
     testM("validate text option 1") {
       val r = f.validate(List("--firstname", "John"), ParserOptions.default)


### PR DESCRIPTION
`PrimType.Bool` consumed subsequent options and arguments for example in: `wc -c -l` (`-l` will be passed as argument to `-c` and cannot be matched as boolean)

This change fixes the bug by not consuming subsequent arguments for boolean options (flags)