### PR TITLE
Add levenstein distance implementation for autocorrect

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/AutoCorrect.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/AutoCorrect.scala
@@ -1,32 +1,33 @@
 package zio.cli
 
 object AutoCorrect {
-  def levensteinDistance(first: String, second: String, opts: ParserOptions): Int = (first.length, second.length) match {
-    case (0, 0) => 0
-    case (0, secondLength) => secondLength
-    case (firstLength, 0) => firstLength
-    case (rowCount, columnCount) => {
-      val matrix = Array.ofDim[Int](rowCount + 1, columnCount + 1)
-      val normalFirst = opts.normalizeCase(first)
-      val normalSecond = opts.normalizeCase(second)
+  def levensteinDistance(first: String, second: String, opts: ParserOptions): Int =
+    (first.length, second.length) match {
+      case (0, 0)            => 0
+      case (0, secondLength) => secondLength
+      case (firstLength, 0)  => firstLength
+      case (rowCount, columnCount) => {
+        val matrix       = Array.ofDim[Int](rowCount + 1, columnCount + 1)
+        val normalFirst  = opts.normalizeCase(first)
+        val normalSecond = opts.normalizeCase(second)
 
-      (0 to rowCount).foreach(x => matrix(x)(0) = x)
-      (0 to columnCount).foreach(x => matrix(0)(x) = x)
+        (0 to rowCount).foreach(x => matrix(x)(0) = x)
+        (0 to columnCount).foreach(x => matrix(0)(x) = x)
 
-      for {
-        row <- (1 to rowCount)
-        col <- (1 to columnCount)
-      } yield {
-        val cost = if (normalFirst.charAt(row - 1) == normalSecond.charAt(col - 1)) 0 else 1
+        for {
+          row <- (1 to rowCount)
+          col <- (1 to columnCount)
+        } yield {
+          val cost = if (normalFirst.charAt(row - 1) == normalSecond.charAt(col - 1)) 0 else 1
 
-        matrix(row)(col) = Seq(
-          matrix(row)(col - 1) + 1,
-          matrix(row - 1)(col) + 1,
-          matrix(row - 1)(col - 1) + cost
-        ).min
+          matrix(row)(col) = Seq(
+            matrix(row)(col - 1) + 1,
+            matrix(row - 1)(col) + 1,
+            matrix(row - 1)(col - 1) + cost
+          ).min
+        }
+
+        matrix(rowCount)(columnCount)
       }
-
-      matrix(rowCount)(columnCount)
     }
-  }
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/AutoCorrect.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/AutoCorrect.scala
@@ -1,0 +1,32 @@
+package zio.cli
+
+object AutoCorrect {
+  def levensteinDistance(first: String, second: String, opts: ParserOptions): Int = (first.length, second.length) match {
+    case (0, 0) => 0
+    case (0, secondLength) => secondLength
+    case (firstLength, 0) => firstLength
+    case (rowCount, columnCount) => {
+      val matrix = Array.ofDim[Int](rowCount + 1, columnCount + 1)
+      val normalFirst = opts.normalizeCase(first)
+      val normalSecond = opts.normalizeCase(second)
+
+      (0 to rowCount).foreach(x => matrix(x)(0) = x)
+      (0 to columnCount).foreach(x => matrix(0)(x) = x)
+
+      for {
+        row <- (1 to rowCount)
+        col <- (1 to columnCount)
+      } yield {
+        val cost = if (normalFirst.charAt(row - 1) == normalSecond.charAt(col - 1)) 0 else 1
+
+        matrix(row)(col) = Seq(
+          matrix(row)(col - 1) + 1,
+          matrix(row - 1)(col) + 1,
+          matrix(row - 1)(col - 1) + cost
+        ).min
+      }
+
+      matrix(rowCount)(columnCount)
+    }
+  }
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/AutoCorrectSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/AutoCorrectSpec.scala
@@ -1,0 +1,26 @@
+package zio.cli
+
+import zio.test.Assertion._
+import zio.test._
+
+object AutoCorrectSpec extends DefaultRunnableSpec {
+  import AutoCorrect._
+
+  def spec = suite("AutoCorrect.levensteinDistance Suite")(
+    test("calculate the correct levenstein distance between two strings") {
+      val opts = ParserOptions.default
+      assert(levensteinDistance("", "", opts))(equalTo(0))
+      assert(levensteinDistance("--force", "", opts))(equalTo(7))
+      assert(levensteinDistance("", "--force", opts))(equalTo(7))
+      assert(levensteinDistance("--force", "force", opts))(equalTo(2))
+      assert(levensteinDistance("--force", "--forc", opts))(equalTo(1))
+      assert(levensteinDistance("--force", "--Force", opts))(equalTo(1))
+      assert(levensteinDistance("foo", "bar", opts))(equalTo(3))
+    },
+    test("takes into account the provided parserOptions case sensitivity") {
+      val opts = ParserOptions(caseSensitive = false)
+      assert(levensteinDistance("--force", "--force", opts))(equalTo(0))
+      assert(levensteinDistance("--FORCE", "--force", opts))(equalTo(0))
+    }
+  )
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/AutoCorrectSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/AutoCorrectSpec.scala
@@ -21,6 +21,11 @@ object AutoCorrectSpec extends DefaultRunnableSpec {
       val opts = ParserOptions(caseSensitive = false)
       assert(levensteinDistance("--force", "--force", opts))(equalTo(0))
       assert(levensteinDistance("--FORCE", "--force", opts))(equalTo(0))
+    },
+    test("calculates the correct levenstein distance for non ascii characters") {
+      val opts = ParserOptions.default
+      assert(levensteinDistance("とんかつ", "とかつ", opts))(equalTo(1))
+      assert(levensteinDistance("¯\\_(ツ)_/¯", "_(ツ)_/¯", opts))(equalTo(2))
     }
   )
 }


### PR DESCRIPTION
A dynamic programming implementation of the levenstein distance algorithm to be able to implement #5. Next steps would be to integrate this into the `Command.parse` function when a option fails to validate. 