### PR TITLE
refactored RequireNot to OrElse

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -23,7 +23,6 @@ import zio.cli.HelpDoc.p
 import zio.cli.HelpDoc.Span._
 
 import scala.collection.immutable.Nil
-import scala.reflect.ClassTag
 
 /**
  * A `Flag[A]` models a command-line flag that produces a value of type `A`.
@@ -75,21 +74,21 @@ sealed trait Options[+A] { self =>
   final def fold[B, C, Z](
     f1: B => Z,
     f2: C => Z
-  )(implicit ev: A <:< Either[B, C], ctb: ClassTag[B], ctc: ClassTag[C]): Options[Z] =
-    self.map {
-      case Left(b: B)  => f1(b)
-      case Right(c: C) => f2(c)
+  )(implicit ev: A <:< Either[B, C]): Options[Z] =
+    self.map(ev).map {
+      case Left(b)  => f1(b)
+      case Right(c) => f2(c)
     }
 
   final def fold[B, C, D, Z](
     f1: B => Z,
     f2: C => Z,
     f3: D => Z
-  )(implicit ev: A <:< Either[Either[B, C], D], ctb: ClassTag[B], ctc: ClassTag[C], ctd: ClassTag[D]): Options[Z] =
-    self.map {
-      case Left(Left(b: B))  => f1(b)
-      case Left(Right(c: C)) => f2(c)
-      case Right(d: D)       => f3(d)
+  )(implicit ev: A <:< Either[Either[B, C], D]): Options[Z] =
+    self.map(ev).map {
+      case Left(Left(b))  => f1(b)
+      case Left(Right(c)) => f2(c)
+      case Right(d)       => f3(d)
     }
 
   final def collect[B](message: String)(f: PartialFunction[A, B]): Options[B] =


### PR DESCRIPTION
Hi!
First of all season's greetings everybody! :-)
This pull request is intended as a first attempt to cover an idea John has expressed in a private conversion while I contacted him for help on issue #70.

John was suggesting the following:
> Actually I think we should delete `requires`/`requiresNot` and solve the problem in a different way:
> By making an `orElse` operator on `Options`.
> Then we can explicitly denote which options are mutually incompatible with each other: `a | b | c (orElse)`.
> We can already denote which options require each other using "cons": `(a :: b) | c` would mean, we require `a` and `b`, or we require `c`. One of the two, but not both.
> Basically the `requires` / `requiresNot` way of solving this problem is hard because it requires non-local solution.
> A compositional solution is preferrable.
> So we should just delete `requires` / `requiresNot` and add `OrElse`.

Introducing `||` worked out wonderfully and feels much more intuitive than the requires/requiresNot operators. I've added a new subtype `OrElse`, removed  `Requires`/`RequiresNot` and added some tests in this pull request.
More work is required to properly render the error messages.