### PR TITLE
Add a figlet font renderer #35

### DIFF
--- a/zio-cli/js/src/main/scala/figlet/FigFontPlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/figlet/FigFontPlatformSpecific.scala
@@ -1,5 +1,4 @@
 package figlet
 
 trait FigFontPlatformSpecific { self: FigFont.type =>
-
 }

--- a/zio-cli/jvm/src/main/scala/figlet/FigFontPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/figlet/FigFontPlatformSpecific.scala
@@ -4,17 +4,28 @@ import zio._
 import zio.blocking.{ effectBlockingIO, Blocking }
 
 import java.io.IOException
-import scala.io.Source
+import scala.io.{ Codec, Source }
 
 trait FigFontPlatformSpecific { self: FigFont.type =>
+  final def fromFile(name: String): ZIO[Blocking, Either[IOException, String], FigFont] =
+    fromSource(effectBlockingIO(Source.fromFile(name)(Codec.ISO8859)))
+
   final def fromResource(name: String, loader: ClassLoader): ZIO[Blocking, Either[IOException, String], FigFont] =
+    fromSource(effectBlockingIO(Source.fromInputStream(loader.getResourceAsStream(name))))
+
+  final def fromURL(url: String): ZIO[Blocking, Either[IOException, String], FigFont] =
+    fromSource(effectBlockingIO(Source.fromURL(url)(Codec.ISO8859)))
+
+  final def fromSource[R <: Blocking, A, E >: IOException](
+    source: => ZIO[R, E, Source]
+  ): ZIO[R, Either[E, String], FigFont] =
     for {
       lines <- ZManaged
-                .fromAutoCloseable(effectBlockingIO(loader.getResourceAsStream(name)))
-                .use { s =>
-                  effectBlockingIO(Source.fromInputStream(s).getLines().to(Seq))
-                }
+                .fromAutoCloseable(source)
+                .use(s => effectBlockingIO(s.getLines().toSeq))
                 .mapError(Left(_))
-      figFont <- ZIO.fromEither(self.fromLines(lines)).mapError(Right(_))
-    } yield figFont
+      font <- ZIO
+               .fromEither(self.fromLines(lines))
+               .mapError(Right(_))
+    } yield font
 }

--- a/zio-cli/jvm/src/test/scala/figlet/FigFontParserSpec.scala
+++ b/zio-cli/jvm/src/test/scala/figlet/FigFontParserSpec.scala
@@ -1,27 +1,24 @@
 package figlet
 
-import zio.test.Assertion._
+import figlet.Layout._
+import figlet.SmushingRule._
 import zio.test._
+import zio.test.Assertion._
 
 object FigFontParserSpec extends DefaultRunnableSpec {
-  import FigFontParser._
-  import ParseResult._
-  import Layout._
-  import SmushingRule._
-
   def spec = suite("FigFontParserSpec")(
     testM("parse standard.flf") {
       for {
         font_         <- FigFont.fromResource("standard.flf", getClass.getClassLoader)
         font: FigFont = font_ // TODO IJ cross-platform projects issue
       } yield {
-        assert(font.header)(equalTo(FigHeader("flf2a", '$', 6, 5, 16, 11, 15, Some(0), Some(24463)))) &&
+        assert(font.header)(equalTo(FigHeader("flf2a", '$', 6, 5, 11, 15, Some(0), Some(24463)))) &&
         assert(font.rightToLeft)(isFalse) &&
         assert(font.layout)(
           equalTo(
             Layouts(
-              Smushing(Seq(EqualCharacter, Underscore, Hierarchy, OppositePair)),
-              Smushing(Seq(EqualCharacter, Underscore, Hierarchy, HorizontalLine, VerticalLineSuperSmushing))
+              Smushing(equalCharacter | underscore | hierarchy | oppositePair),
+              Smushing(equalCharacter | underscore | hierarchy | horizontalLine | verticalLineSupersmushing)
             )
           )
         ) &&
@@ -50,25 +47,6 @@ object FigFontParserSpec extends DefaultRunnableSpec {
           )
         )
       }
-//    } @@ TestAspect.ignore,
-    },
-    suite("line parsing")(
-      test("chars") {
-        assert(chars(2)(LineSpan("1234")))(equalTo(Ok(LineSpan("1234", 2), "12"))) &&
-        assert(chars(2)(LineSpan("1234", 2)))(equalTo(Ok(LineSpan("1234", 4), "34"))) &&
-        assert(chars(3).parse(LineSpan("1234", 2)))(isLeft(equalTo("3:EOL before 3th char")))
-      },
-      test("char") {
-        assert(char('b')(LineSpan("abc", 1)))(equalTo(Ok(LineSpan("abc", 2), ()))) &&
-        assert(char('a').parse(LineSpan("ab", 1)))(isLeft(equalTo("2:'a' expected, found 'b'")))
-      },
-      test("token") {
-        assert(token(LineSpan("1a2b", 1)))(equalTo(Ok(LineSpan("1a2b", 4), "a2b")))
-
-      },
-      test("int") {
-        assert(int(LineSpan("a123", 1)))(equalTo(Ok(LineSpan("a123", 4), 123)))
-      }
-    )
+    }
   )
 }

--- a/zio-cli/jvm/src/test/scala/figlet/FigFontRenderReportSpec.scala
+++ b/zio-cli/jvm/src/test/scala/figlet/FigFontRenderReportSpec.scala
@@ -1,0 +1,72 @@
+package figlet
+
+import zio._
+import zio.blocking._
+import zio.console.putStrLn
+import zio.test._
+import zio.test.Assertion._
+
+import scala.io.Source
+import java.nio.file._
+import scala.util.Using
+
+object FigFontRenderReportSpec extends DefaultRunnableSpec {
+  private val fontDbUrl = "http://www.figlet.org/fontdb.cgi"
+  private val fontUrl   = "http://www.figlet.org/fonts/"
+
+  override def spec = suite("FigFontRenderReportSpec")(
+    testM("figlet.org Fonts Render Report") {
+      for {
+        fontDbHtml <- ZManaged
+                       .fromAutoCloseable(effectBlockingIO(Source.fromURL(fontDbUrl)))
+                       .use(s => effectBlockingIO(s.getLines().mkString))
+        names = "(?<=\\?font=)[\\w-]+\\.flf".r.findAllIn(fontDbHtml).toSeq
+        items <- ZIO.foreachPar(names) { name =>
+                  val url = s"$fontUrl$name"
+                  FigFont
+                    .fromURL(url)
+                    .fold({
+                      case Left(e)  => Left(e.toString)
+                      case Right(s) => Left(s)
+                    }, f => renderOrError(f))
+                    .map(r => (url, r))
+                }
+        title = s"$fontUrl Render Report"
+        path  <- renderReport(title, items)
+        _     <- putStrLn(s"$title: $path")
+      } yield assert(items.collect { case (url, Left(s)) => (url, s) })(isEmpty)
+    } @@ TestAspect.ignore
+//    }
+  )
+
+  private def renderOrError(font: FigFont) =
+    try {
+      val (abc, rest)    = font.chars.keys.partition(_.isLetter)
+      val (lower, upper) = abc.partition(_.isLower)
+      val sample         = Seq(lower, upper, rest).map(_.mkString).mkString("\n")
+      Right(FigFont.render(font, sample))
+    } catch {
+      case t: Throwable => Left(t.toString)
+    }
+
+  private def renderReport(title: String, items: Seq[(String, Either[String, Chunk[String]])]) = effectBlocking {
+    val path = Files.createTempFile("figlet-report", ".md")
+    Using(Files.newBufferedWriter(path)) { w =>
+      w.write(s"# $title\n")
+      items.foreach {
+        case (url, Left(s)) =>
+          w.write(s"\n* __[FAILED]__ <$url>\n```\n")
+          w.write(s)
+          w.write("```\n")
+        case (url, Right(lines)) =>
+          w.write(s"\n* <$url>\n```\n")
+          lines.foreach { l =>
+            w.write(l)
+            w.write('\n')
+          }
+          w.write("```\n")
+      }
+    }
+    path.toUri.toString
+  }
+}

--- a/zio-cli/jvm/src/test/scala/figlet/FigFontRenderReportSpec.scala
+++ b/zio-cli/jvm/src/test/scala/figlet/FigFontRenderReportSpec.scala
@@ -41,7 +41,7 @@ object FigFontRenderReportSpec extends DefaultRunnableSpec {
 
   private def renderOrError(font: FigFont) =
     try {
-      val (abc, rest)    = font.chars.keys.partition(_.isLetter)
+      val (abc, rest)    = font.chars.keys.toSeq.sorted.partition(_.isLetter)
       val (lower, upper) = abc.partition(_.isLower)
       val sample         = Seq(lower, upper, rest).map(_.mkString).mkString("\n")
       Right(FigFont.render(font, sample))

--- a/zio-cli/jvm/src/test/scala/figlet/FigFontRendererJvmSpec.scala
+++ b/zio-cli/jvm/src/test/scala/figlet/FigFontRendererJvmSpec.scala
@@ -1,0 +1,33 @@
+package figlet
+
+import figlet.FigFontRenderer.render
+import figlet.FigFontRendererSpec.assertTextBlock
+import zio.test._
+
+object FigFontRendererJvmSpec extends DefaultRunnableSpec {
+  def spec = suite("FigFontRendererSpec")(
+    testM("ZIO-CLI!!! with standard.flf") {
+      for {
+        font_         <- FigFont.fromResource("standard.flf", getClass.getClassLoader)
+        font: FigFont = font_ // TODO IJ cross-platform projects issue
+        r             = render(font, "ZIO-\nCLI!!!")
+      } yield {
+        assertTextBlock(
+          r,
+          """
+            | _____ ___  ___        |
+            ||__  /|_ _|/ _ \       |
+            |  / /  | || | | |_____ |
+            | / /_  | || |_| |_____||
+            |/____||___|\___/       |
+            |  ____ _     ___  _ _ _ |
+            | / ___| |   |_ _|| | | ||
+            || |   | |    | | | | | ||
+            || |___| |___ | | |_|_|_||
+            | \____|_____|___|(_|_|_)|
+            |                        |"""
+        )
+      }
+    } @@ TestAspect.jvmOnly
+  )
+}

--- a/zio-cli/shared/src/main/scala/figlet/FigFontParser.scala
+++ b/zio-cli/shared/src/main/scala/figlet/FigFontParser.scala
@@ -33,7 +33,7 @@ private[figlet] object FigFontParser {
     hardBlank      <- chars(1).map(_.head)
     charHeight     <- space ~> int
     baseline       <- space ~> int
-    maxLength      <- space ~> int
+    _              <- space ~> int // we have no use for maxLength
     oldLayoutMask  <- space ~> int
     commentLines   <- space ~> int
     rightToLeft    <- (space ~> int).?
@@ -43,7 +43,6 @@ private[figlet] object FigFontParser {
     hardBlank = hardBlank,
     charHeight = charHeight,
     baseline = baseline,
-    maxLength = maxLength,
     commentLines = commentLines,
     oldLayoutMask = oldLayoutMask,
     rightToLeft = rightToLeft,

--- a/zio-cli/shared/src/main/scala/figlet/FigFontRenderer.scala
+++ b/zio-cli/shared/src/main/scala/figlet/FigFontRenderer.scala
@@ -1,3 +1,150 @@
 package figlet
 
-object FigFontRenderer {}
+import zio.Chunk
+import scala.math.{ max, min }
+import Layout._
+import SmushingRule._
+import FigCharLine._
+
+private[figlet] object FigFontRenderer {
+  // TODO add support for RTL
+  def render(font: FigFont, text: String): Chunk[String] = {
+    val (hb, h, rtl)              = (font.header.hardBlank, font.header.charHeight, font.rightToLeft)
+    val Layouts(hLayout, vLayout) = font.layout
+    val emptyFigChar              = FigChar(Chunk.fill(h)(Empty(0)), 0, h)
+    val missingFigChar            = font.chars.getOrElse('\u0000', emptyFigChar)
+
+    // TODO add renderOptions e.g. maxWidth to implement word-wrapping
+    // TODO review whether to trim vertically (or only at the bottom) given we trim horizontally
+    def renderLine(line: String): Chunk[Chunk[String]] = Chunk(
+      line.map(font.chars.getOrElse(_, missingFigChar)).fold(emptyFigChar)(hAppend).fullLines(trim = true)
+    )
+
+    def hAppend(b1: FigChar, b2: FigChar): FigChar = {
+      val f = measure(hb, hLayout, rtl, h, b1, b2)
+      val lines = b1.lines.zipWith(b2.lines) { (l1, l2) =>
+        (l1, l2) match {
+          case (Empty(r), Empty(l))         => Empty(r - f + l)
+          case (Empty(r), Chars(l, s2, r2)) => Chars(r - f + l, s2, r2)
+          case (Chars(l1, s1, r), Empty(l)) => Chars(l1, s1, r - f + l)
+          case (Chars(l1, s1, r), Chars(l, s2, r2)) =>
+            Chars(l1, hLayout match {
+              case Smushing(rules) if r - f + l < 0 => s1.dropRight(1) + smush(hb, rules, s1.last, s2.head) + s2.drop(1)
+              case _                                => s1 + " " * (r - f + l) + s2
+            }, r2)
+        }
+      }
+      FigChar(lines, b1.width + b2.width - f, h)
+    }
+
+    def vAppend(b1: Chunk[String], b2: Chunk[String]): Chunk[String] = {
+      val f = measure(hb, vLayout, rtl = false, height = max(b1(0).length, b2(0).length), b1, b2)
+      val merge = b1.takeRight(f).zipWith(b2.take(f)) { (l1, l2) =>
+        val chars = Array.tabulate(min(l1.length, l2.length))(i =>
+          (l1.charAt(i), l2.charAt(i)) match {
+            case (' ', c) => c
+            case (c, ' ') => c
+            case (c1, c2) =>
+              vLayout match {
+                case Smushing(rules) => smush(hb, rules, c1, c2)
+                case _               => ??? // measure allows to overlap only for Smushing
+              }
+          }
+        )
+        new String(chars) + l1.drop(chars.length) + l2.drop(chars.length)
+      }
+      b1.dropRight(f) ++ merge ++ b2.drop(f)
+    }
+
+    text.linesIterator
+      .flatMap(renderLine)
+      .reduce(vAppend)
+      .map(_.replace(hb, ' '))
+  }
+
+  private trait Block[A] {
+    def width(a: A): Int
+    def spaces(a: A, row: Int, rtl: Boolean): Int
+    def charAt(a: A, row: Int, n: Int, rtl: Boolean): Char
+  }
+
+  private val MISSING = '\uDBFF'
+
+  private implicit object FigCharBlock extends Block[FigChar] {
+    override def width(a: FigChar): Int = a.width
+
+    override def spaces(a: FigChar, row: Int, rtl: Boolean): Int = a.lines(row).spaces(rtl)
+
+    override def charAt(a: FigChar, row: Int, n: Int, rtl: Boolean): Char = a.lines(row) match {
+      case Empty(w) => if (n < w) ' ' else MISSING
+      case Chars(l, s, r) =>
+        val i = if (rtl) s.length - 1 - (n - r) else n - l
+        if (0 <= i && i < s.length) s.charAt(i) else MISSING
+    }
+  }
+
+  private implicit object StringChunkBlock extends Block[Chunk[String]] {
+    override def width(a: Chunk[String]): Int = a.size
+
+    override def spaces(a: Chunk[String], row: Int, rtl: Boolean): Int =
+      if (rtl) a.lastIndexWhere(l => row < l.length && l.charAt(row) != ' ') match {
+        case -1 => a.size
+        case i  => a.size - 1 - i
+      }
+      else
+        a.indexWhere(l => l.length > row && l.charAt(row) != ' ') match {
+          case -1 => a.size
+          case i  => i
+        }
+
+    override def charAt(a: Chunk[String], row: Int, n: Int, rtl: Boolean): Char =
+      a(if (rtl) a.size - 1 - n else n).charAt(row)
+  }
+
+  private def measure[A](hb: Char, layout: Layout[_], rtl: Boolean, height: Int, b1: A, b2: A)(implicit ev: Block[A]) =
+    layout match {
+      case FullWidth => 0
+      case Fitting   => (0 until height).map(r => ev.spaces(b1, r, !rtl) + ev.spaces(b2, r, rtl)).min
+      case Smushing(rules) =>
+        (0 until height).foldLeft(ev.width(b1) + ev.width(b2)) { (fitting, r) =>
+          val s1 = ev.spaces(b1, r, !rtl)
+          val s2 = ev.spaces(b2, r, rtl)
+          s1 + s2 match {
+            case f if f >= fitting => fitting
+            case f =>
+              (ev.charAt(b1, r, s1, !rtl), ev.charAt(b2, r, s2, rtl)) match {
+                case (MISSING, _) | (_, MISSING) => f
+                case (c1, c2) =>
+                  smush(hb, rules, c1, c2) match {
+                    case MISSING => f
+                    // vertical line supersmushing can smush all vertically adjacent |
+                    case '|' if verticalLineSupersmushing.unapply(rules) && c1 == '|' && c2 == '|' =>
+                      val rng = 1 until fitting - f
+                      f + 1 +
+                        rng.takeWhile(i => ev.charAt(b1, r, s1 + i, !rtl) == '|').length +
+                        rng.takeWhile(i => ev.charAt(b2, r, s2 + i, rtl) == '|').length
+                    case _ => f + 1
+                  }
+              }
+          }
+        }
+    }
+
+  private def smush(hb: Char, rules: SmushingRule[_], a: Char, b: Char): Char = rules match {
+    case universal()                                              => if (a != hb && b != hb) b else MISSING
+    case equalCharacter() if a == b && a != hb                    => b
+    case hardblank() if a == hb && b == hb                        => hb
+    case underscore() if a == '_' && "|/\\[]{}()<>".contains(b)   => b
+    case bigX() if eq(pos(a, "/\\>"), pos(b, "\\/<"))             => "|YX".charAt(pos(a, "/\\>"))
+    case oppositePair() if eq(pos(a, "[]{}()"), pos(b, "][}{)(")) => '|'
+    case hierarchy() if notEq(pos(a, "||/\\[]{}()<>") / 2, pos(a, "||/\\[]{}()<>") / 2) =>
+      if (pos(a, "||/\\[]{}()<>") > pos(b, "||/\\[]{}()<>")) a else b
+    case horizontalLine() if a == '-' && b == '_' || a == '_' && b == '-' => '='
+    case verticalLineSupersmushing() if a == '|' && b == '|'              => '|'
+    case _                                                                => MISSING
+  }
+
+  private def pos(c: Char, s: String) = s.indexOf(Char.char2int(c))
+  private def eq(a: Int, b: Int)      = a >= 0 && a == b
+  private def notEq(a: Int, b: Int)   = a >= 0 && b >= 0 && a != b
+}

--- a/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
+++ b/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
@@ -1,0 +1,174 @@
+package figlet
+
+import figlet.FigFontRenderer.render
+import figlet.Layout._
+import figlet.LayoutDirection._
+import figlet.SmushingRule._
+import zio.test.Assertion._
+import zio.test._
+import zio.Chunk
+
+import scala.annotation.tailrec
+
+object FigFontRendererSpec extends DefaultRunnableSpec {
+  private val header = FigHeader("flf2a", '$', 6, 5, 16, 15, Some(0), Some(24463))
+  private val font = testFigFont(
+    """
+      |J    T    -    |   |
+      |  ** *****       | |
+      |   *   *   ***   | |
+      |*  *   *        $|$|
+      | **    *         | |
+      |                 | |"""
+  )
+
+  override def spec = suite("FigFontRendererSpec")(
+    test("FullWidth HLayout") {
+      assertTextBlock(
+        render(font.withHLayout(FullWidth), "-?TJ-"),
+        """
+          |    *****  **     |
+          |***   *     *  ***|
+          |      *  *  *     |
+          |      *   **      |
+          |                  |"""
+      )
+    },
+    test("Fitting HLayout") {
+      assertTextBlock(
+        render(font.withHLayout(Fitting), "-?TJ-"),
+        """
+          | *******   |
+          |****   ****|
+          |   **  *   |
+          |   * **    |
+          |           |"""
+      )
+    },
+    test("Equal Char Smushing HLayout") {
+      assertTextBlock(
+        render(font.withHLayout(Smushing(equalCharacter)), "-?TJ-"),
+        """
+          |******  |
+          |***  ***|
+          |  *  *  |
+          |  ***   |
+          |        |"""
+      )
+    },
+    test("FullWidth VLayout") {
+      val r = render(font.withVLayout(FullWidth), "T\nJ")
+      assert(TextBlock(r))(equalTo(textBlock("""
+          |*****|
+          |  *  |
+          |  *  |
+          |  *  |
+          |     |
+          |  **|
+          |   *|
+          |*  *|
+          | ** |
+          |    |""")))
+
+    },
+    test("Hardblanks") {
+      assertTextBlock(
+        render(font.withHLayout(Smushing(equalCharacter)), "||"),
+        """
+          | |  | |
+          | |  | |
+          | |  | |
+          | |  | |
+          | |  | |"""
+      )
+
+    },
+    test("Fitting VLayout") {
+      assertTextBlock(
+        render(font.withVLayout(Fitting), "T\nJ"),
+        """
+          |*****|
+          |  *  |
+          |  *  |
+          |  *  |
+          |  ** |
+          |   *|
+          |*  *|
+          | ** |
+          |    |"""
+      )
+
+    },
+    test("Equal Char Smushing VLayout") {
+      assertTextBlock(
+        render(font.withVLayout(Smushing(equalCharacter)), "T\nJ"),
+        """
+          |*****|
+          |  *  |
+          |  *  |
+          |  ** |
+          |   * |
+          |*  *|
+          | ** |
+          |    |"""
+      )
+    },
+    test("Vertical Line Supersmushing") {
+      assertTextBlock(
+        render(font.withVLayout(Smushing(equalCharacter | verticalLineSupersmushing)), "|\n|"),
+        """
+          | | |
+          | | |
+          | | |
+          | | |
+          | | |
+          | | |"""
+      )
+    }
+  )
+
+  private final case class TextBlock(lines: Chunk[String]) {
+    override def toString: String = ("" +: lines.map(l => s"|$l|") :+ "").mkString("\n")
+  }
+
+  private def textBlock(s: String) =
+    TextBlock(Chunk.fromIterable(s.stripMargin.linesIterator.dropWhile(_.isBlank).map(_.stripSuffix("|")).toSeq))
+
+  def assertTextBlock(actual: Chunk[String], expected: String): TestResult =
+    assert(TextBlock(actual))(equalTo(textBlock(expected)))
+
+  private def testFigFont(s: String) = textBlock(s).lines.splitAt(1) match {
+    case (MyNonEmptyChunk(h), lines) =>
+      @tailrec def parse(chars: Map[Char, FigChar], from: Int): Map[Char, FigChar] =
+        if (from < h.length) {
+          val i = h.indexWhere(_ != ' ', from + 1) match {
+            case -1 => h.length
+            case i  => i
+          }
+          val width = i - from
+          val fc    = FigChar(lines.map(l => FigCharLine.fromFullLine(width, l.substring(from, i))), width, lines.size)
+          parse(chars + (h.charAt(from) -> fc), i)
+        } else chars
+
+      FigFont(
+        header = header.copy(charHeight = lines.size),
+        rightToLeft = false,
+        Layouts(FullWidth, FullWidth),
+        parse(Map.empty, 0)
+      )
+  }
+
+  implicit final class FigFontOps(private val font: FigFont) {
+    def withHLayout(hLayout: Layout[Horizontal]): FigFont = font.copy(layout = font.layout.copy(horizontal = hLayout))
+    def withVLayout(vLayout: Layout[Vertical]): FigFont   = font.copy(layout = font.layout.copy(vertical = vLayout))
+  }
+
+  // TODO remove once https://github.com/zio/zio/pull/4310 released
+  object MyNonEmptyChunk {
+    def unapplySeq[A](seq: Seq[A]): Option[Seq[A]] =
+      seq match {
+        case chunk: Chunk[A] if chunk.nonEmpty => Some(chunk)
+        case _                                 => None
+      }
+  }
+}

--- a/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
+++ b/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
@@ -131,8 +131,14 @@ object FigFontRendererSpec extends DefaultRunnableSpec {
     override def toString: String = ("" +: lines.map(l => s"|$l|") :+ "").mkString("\n")
   }
 
-  private def textBlock(s: String) =
-    TextBlock(Chunk.fromIterable(s.stripMargin.linesIterator.dropWhile(_.isBlank).map(_.stripSuffix("|")).toSeq))
+  private def textBlock(s: String) = TextBlock(
+    Chunk.fromIterable(
+      s.stripMargin.linesIterator
+        .dropWhile(l => l.forall(_.isWhitespace))
+        .map(_.stripSuffix("|"))
+        .toSeq
+    )
+  )
 
   def assertTextBlock(actual: Chunk[String], expected: String): TestResult =
     assert(TextBlock(actual))(equalTo(textBlock(expected)))

--- a/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
+++ b/zio-cli/shared/src/test/scala/figlet/FigFontRendererSpec.scala
@@ -32,6 +32,15 @@ object FigFontRendererSpec extends DefaultRunnableSpec {
           |      *  *  *     |
           |      *   **      |
           |                  |"""
+      ) &&
+      assertTextBlock(
+        render(font.withHLayout(FullWidth).copy(rightToLeft = true), "-?TJ-"),
+        """
+          |    *****  **     |
+          |***   *     *  ***|
+          |      *  *  *     |
+          |      *   **      |
+          |                  |"""
       )
     },
     test("Fitting HLayout") {
@@ -43,11 +52,29 @@ object FigFontRendererSpec extends DefaultRunnableSpec {
           |   **  *   |
           |   * **    |
           |           |"""
+      ) &&
+      assertTextBlock(
+        render(font.withHLayout(Fitting).copy(rightToLeft = true), "-?TJ-"),
+        """
+          | *******   |
+          |****   ****|
+          |   **  *   |
+          |   * **    |
+          |           |"""
       )
     },
     test("Equal Char Smushing HLayout") {
       assertTextBlock(
         render(font.withHLayout(Smushing(equalCharacter)), "-?TJ-"),
+        """
+          |******  |
+          |***  ***|
+          |  *  *  |
+          |  ***   |
+          |        |"""
+      ) &&
+      assertTextBlock(
+        render(font.withHLayout(Smushing(equalCharacter)).copy(rightToLeft = true), "-?TJ-"),
         """
           |******  |
           |***  ***|
@@ -123,6 +150,27 @@ object FigFontRendererSpec extends DefaultRunnableSpec {
           | | |
           | | |
           | | |"""
+      )
+    },
+    test("Universal Smushing") {
+      val font = testFigFont("""
+          |12|
+          | B|
+          |AB|
+          |A |""").withHLayout(Smushing(universal))
+      assertTextBlock(
+        render(font, "12"),
+        """
+          |B|
+          |B|
+          |A|"""
+      ) &&
+      assertTextBlock(
+        render(font.copy(rightToLeft = true), "12"),
+        """
+          |B|
+          |A|
+          |A|"""
       )
     }
   )

--- a/zio-cli/shared/src/test/scala/figlet/LineSpanParserSpec.scala
+++ b/zio-cli/shared/src/test/scala/figlet/LineSpanParserSpec.scala
@@ -1,0 +1,29 @@
+package figlet
+
+import zio.test._
+import zio.test.Assertion._
+import FigFontParser._
+import ParseResult._
+
+object LineSpanParserSpec extends DefaultRunnableSpec {
+  def spec = suite("FigFontParserSpec")(
+    suite("line parsing")(
+      test("chars") {
+        assert(chars(2)(LineSpan("1234")))(equalTo(Ok(LineSpan("1234", 2), "12"))) &&
+        assert(chars(2)(LineSpan("1234", 2)))(equalTo(Ok(LineSpan("1234", 4), "34"))) &&
+        assert(chars(3).parse(LineSpan("1234", 2)))(isLeft(equalTo("3:EOL before 3th char")))
+      },
+      test("char") {
+        assert(char('b')(LineSpan("abc", 1)))(equalTo(Ok(LineSpan("abc", 2), ()))) &&
+        assert(char('a').parse(LineSpan("ab", 1)))(isLeft(equalTo("2:'a' expected, found 'b'")))
+      },
+      test("token") {
+        assert(token(LineSpan("1a2b", 1)))(equalTo(Ok(LineSpan("1a2b", 4), "a2b")))
+
+      },
+      test("int") {
+        assert(int(LineSpan("a123", 1)))(equalTo(Ok(LineSpan("a123", 4), 123)))
+      }
+    )
+  )
+}


### PR DESCRIPTION
@jdegoes just few notes:

* smushing rules previously encoded with a set of case objects are replaced by a mask newtype as it suites better for the rendering code -- that's my first attempt of such encoding, your feedback is appreciated :wink: 
* trying to keep most code in the shared project except IO -- not sure about the expected JS env for zio-cli (I guess it's NodeJS, do we have a complete sample for it?) -- i think `FigFont.fromResource` makes most sense for a CLI app, so i'd like to figure out something equivalent for NodeJS
* `FigFontRenderReportSpec` downloads fonts from [figlet.org](http://www.figlet.org/fontdb.cgi) and generates a .md report (see [figlet-report.md](https://gist.github.com/domartynov/bc93b606af11006806b72266bb5a8fda))



