### PR TITLE
Fix crlf end-of-line in FigFontFiles.scala

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/figlet/FigFontFiles.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/figlet/FigFontFiles.scala
@@ -1299,5 +1299,5 @@ __/_/_@
 /____/    @@
 """
 
-  val Default: FigFont = FigFont.fromLines(Text.split("\n")).toOption.get
+  val Default: FigFont = FigFont.fromLines(Text.linesIterator.toSeq).toOption.get
 }


### PR DESCRIPTION
@jdegoes somehow you've committed FigFontFiles.scala with CRLF, i wonder what's your `git config core.autocrlf` then (usually we keep text files with LF in the repo, right?). Either way, CRLF is expected on Windows, so i'm replacing `.split('\n')` with `.linesItertor.toSql` (@adamgfraser has added `Chunk.fromIterator` to zio, by it's not released yet).

Btw do we need `zio-cli/shared/src/main/resources/slant.flf` given `FigFontFiles` has it embedded?