### PR TITLE
Refactor Options :: to ++

### DIFF
--- a/examples/shared/src/main/scala/zio/cli/examples/WcApp.scala
+++ b/examples/shared/src/main/scala/zio/cli/examples/WcApp.scala
@@ -25,7 +25,7 @@ object WcApp extends App {
     countChar: Option[Long]
   )
 
-  val options = (bytesFlag :: linesFlag :: wordsFlag :: charFlag).as(WcOptions)
+  val options = (bytesFlag ++ linesFlag ++ wordsFlag ++ charFlag).as(WcOptions)
 
   val args = Args.file("files", Exists.Yes).repeat1
 

--- a/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
@@ -8,7 +8,7 @@ object BuiltInOption {
   final case class BuiltIn(help: Boolean, shellCompletions: Option[ShellType])
 
   lazy val builtInOptions: Options[BuiltIn] =
-    (Options.bool("help", ifPresent = true) :: ShellType.option.optional("N/A")).as(BuiltIn)
+    (Options.bool("help", ifPresent = true) ++ ShellType.option.optional("N/A")).as(BuiltIn)
 
   def builtInOptions(helpDoc: => HelpDoc, completions: ShellType => Set[List[String]]): Options[Option[BuiltInOption]] =
     builtInOptions.map {

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -72,7 +72,7 @@ object Command {
       }
 
       val optionsSection = {
-        val opts = (self.options :: BuiltInOption.builtInOptions).helpDoc
+        val opts = (self.options ++ BuiltInOption.builtInOptions).helpDoc
 
         if (opts == HelpDoc.Empty) HelpDoc.Empty
         else h1("options") + opts

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -31,8 +31,8 @@ sealed trait Options[+A] { self =>
 
   import Options.Single
 
-  final def ::[That, A1 >: A](that: Options[That]): Options[(That, A1)] =
-    Options.Cons(that, self)
+  final def ++[A1 >: A, That](that: Options[That]): Options[(A1, That)] =
+    Options.Cons(self, that)
 
   final def |[A1 >: A](that: Options[A1]): Options[A1] = self.orElse(that)
 
@@ -59,22 +59,22 @@ sealed trait Options[+A] { self =>
 
   //TODO : spend time to understand usage of implicit here
 
-  final def as[B, C, Z](f: (B, C) => Z)(implicit ev: A <:< ((B, C))): Options[Z] =
+  final def as[B, C, Z](f: (B, C) => Z)(implicit ev: A <:< (B, C)): Options[Z] =
     self.map(ev).map { case ((b, c)) => f(b, c) }
 
-  final def as[B, C, D, Z](f: (B, C, D) => Z)(implicit ev: A <:< ((B, (C, D)))): Options[Z] =
-    self.map(ev).map { case ((b, (c, d))) => f(b, c, d) }
+  final def as[B, C, D, Z](f: (B, C, D) => Z)(implicit ev: A <:< ((B, C), D)): Options[Z] =
+    self.map(ev).map { case ((b, c), d) => f(b, c, d) }
 
-  final def as[B, C, D, E, Z](f: (B, C, D, E) => Z)(implicit ev: A <:< ((B, (C, (D, E))))): Options[Z] =
-    self.map(ev).map { case ((b, (c, (d, e)))) => f(b, c, d, e) }
+  final def as[B, C, D, E, Z](f: (B, C, D, E) => Z)(implicit ev: A <:< (((B, C), D), E)): Options[Z] =
+    self.map(ev).map { case (((b, c), d), e) => f(b, c, d, e) }
 
-  final def as[B, C, D, E, F, Z](f0: (B, C, D, E, F) => Z)(implicit ev: A <:< ((B, (C, (D, (E, F)))))): Options[Z] =
-    self.map(ev).map { case ((b, (c, (d, (e, f))))) => f0(b, c, d, e, f) }
+  final def as[B, C, D, E, F, Z](f0: (B, C, D, E, F) => Z)(implicit ev: A <:< ((((B, C), D), E), F)): Options[Z] =
+    self.map(ev).map { case ((((b, c), d), e), f) => f0(b, c, d, e, f) }
 
   final def as[B, C, D, E, F, G, Z](
     f0: (B, C, D, E, F, G) => Z
-  )(implicit ev: A <:< ((B, (C, (D, (E, (F, G))))))): Options[Z] =
-    self.map(ev).map { case ((b, (c, (d, (e, (f, g)))))) => f0(b, c, d, e, f, g) }
+  )(implicit ev: A <:< (((((B, C), D), E), F), G)): Options[Z] =
+    self.map(ev).map { case (((((b, c), d), e), f), g) => f0(b, c, d, e, f, g) }
 
   final def fold[B, C, Z](
     f1: B => Z,
@@ -146,15 +146,15 @@ sealed trait Options[+A] { self =>
 
   final def flatten2[B, C](implicit ev: A <:< ((B, C))): Options[(B, C)] = as[B, C, (B, C)]((_, _))
 
-  final def flatten3[B, C, D](implicit ev: A <:< ((B, (C, D)))): Options[(B, C, D)] = as[B, C, D, (B, C, D)]((_, _, _))
+  final def flatten3[B, C, D](implicit ev: A <:< ((B, C), D)): Options[(B, C, D)] = as[B, C, D, (B, C, D)]((_, _, _))
 
-  final def flatten4[B, C, D, E](implicit ev: A <:< ((B, (C, (D, E))))): Options[(B, C, D, E)] =
+  final def flatten4[B, C, D, E](implicit ev: A <:< (((B, C), D), E)): Options[(B, C, D, E)] =
     as[B, C, D, E, (B, C, D, E)]((_, _, _, _))
 
-  final def flatten5[B, C, D, E, F](implicit ev: A <:< ((B, (C, (D, (E, F)))))): Options[(B, C, D, E, F)] =
+  final def flatten5[B, C, D, E, F](implicit ev: A <:< ((((B, C), D), E), F)): Options[(B, C, D, E, F)] =
     as[B, C, D, E, F, (B, C, D, E, F)]((_, _, _, _, _))
 
-  final def flatten6[B, C, D, E, F, G](implicit ev: A <:< ((B, (C, (D, (E, (F, G))))))): Options[(B, C, D, E, F, G)] =
+  final def flatten6[B, C, D, E, F, G](implicit ev: A <:< (((((B, C), D), E), F), G)): Options[(B, C, D, E, F, G)] =
     as[B, C, D, E, F, G, (B, C, D, E, F, G)]((_, _, _, _, _, _))
 
   def helpDoc: HelpDoc

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -13,10 +13,10 @@ object CommandSpec extends DefaultRunnableSpec {
       suite("Command with options followed by args")(
         testM("Should validate successfully") {
           assertM(Tail.command.parse(List("-n", "100", "foo.log"), CliConfig.default))(
-            equalTo((List.empty[String], (BigInt(100), "foo.log")))
+            equalTo(CommandDirective.UserDefined(List.empty[String], (BigInt(100), "foo.log")))
           ) *>
             assertM(Ag.command.parse(List("--after", "2", "--before", "3", "fooBar"), CliConfig.default))(
-              equalTo((List.empty[String], ((BigInt(2), BigInt(3)), "fooBar")))
+              equalTo(CommandDirective.UserDefined(List.empty[String], ((BigInt(2), BigInt(3)), "fooBar")))
             )
         },
         testM("Should provide auto correct suggestions for misspelled options") {

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -61,7 +61,7 @@ object CommandSpec extends DefaultRunnableSpec {
     val wordsFlag: Options[Boolean] = Options.bool("w", true)
     val charFlag: Options[Boolean]  = Options.bool("m", false)
 
-    val options = bytesFlag :: linesFlag :: wordsFlag :: charFlag
+    val options = bytesFlag ++ linesFlag ++ wordsFlag ++ charFlag
 
     val args = Args.text("files") *
 
@@ -72,7 +72,7 @@ object CommandSpec extends DefaultRunnableSpec {
     val afterFlag: Options[BigInt]  = Options.integer("after").alias("A")
     val beforeFlag: Options[BigInt] = Options.integer("before").alias("B")
 
-    val options = afterFlag :: beforeFlag
+    val options = afterFlag ++ beforeFlag
 
     val args = Args.text
 

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -16,7 +16,7 @@ object OptionsSpec extends DefaultRunnableSpec {
   val aOpt: Options[Option[BigInt]] = Options.integer("age").optional("N/A")
   val b: Options[Boolean]           = Options.bool("verbose", true)
 
-  val options = f :: l :: a
+  val options = f ++ l ++ a
 
   def spec = suite("Options Suite")(
     testM("validate boolean option without value") {
@@ -25,7 +25,7 @@ object OptionsSpec extends DefaultRunnableSpec {
       assertM(r)(equalTo(List() -> true))
     },
     testM("validate boolean option with followup option") {
-      val o = Options.bool("help", true) :: Options.bool("v", true)
+      val o = Options.bool("help", true) ++ Options.bool("v", true)
 
       for {
         v1 <- o.validate(Nil, CliConfig.default)
@@ -67,14 +67,14 @@ object OptionsSpec extends DefaultRunnableSpec {
     },
     testM("validate options for cons") {
       val r = options.validate(List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default)
-      assertM(r)(equalTo(List() -> ("John" -> ("Doe" -> BigInt(100)))))
+      assertM(r)(equalTo(List() -> (("John" -> "Doe") -> BigInt(100))))
     },
     testM("validate options for cons with remainder") {
       val r = options.validate(
         List("--verbose", "true", "--firstname", "John", "--lastname", "Doe", "--age", "100", "--silent", "false"),
         CliConfig.default
       )
-      assertM(r)(equalTo(List("--verbose", "true", "--silent", "false") -> ("John" -> ("Doe" -> BigInt(100)))))
+      assertM(r)(equalTo(List("--verbose", "true", "--silent", "false") -> (("John" -> "Doe") -> BigInt(100))))
     },
     testM("validate non supplied optional") {
       val r = aOpt.validate(List(), CliConfig.default)


### PR DESCRIPTION
Hi all,
John mentioned in a direct messages that it would be better to make the `Options` `::` operator more consistent with the `++` operator of the `Args` class. This pull request implements this refactoring.
This pull request also contains a minor update to the tests following the introduction of `CommandDirective`.