### PR TITLE
simplify options parsing.

### DIFF
--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -65,6 +65,19 @@ object OptionsSpec extends DefaultRunnableSpec {
       val r = f.validate(List("--firstname"), CliConfig.default)
       assertM(r.either)(isLeft)
     },
+    testM("validate case sensitive CLI config") {
+      val caseSensitiveConfig = CliConfig(true, 2)
+      val f: Options[String]  = Options.text("Firstname").alias("F")
+      for {
+        r1 <- f.validate(List("--Firstname", "John"), caseSensitiveConfig)
+        r2 <- f.validate(List("-F", "John"), caseSensitiveConfig)
+        _  <- f.validate(List("--firstname", "John"), caseSensitiveConfig).flip
+        _  <- f.validate(List("--firstname", "John"), caseSensitiveConfig).flip
+      } yield {
+        assert(r1)(equalTo(List() -> "John")) &&
+        assert(r2)(equalTo(List() -> "John"))
+      }
+    },
     testM("validate options for cons") {
       val r = options.validate(List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default)
       assertM(r)(equalTo(List() -> (("John" -> "Doe") -> BigInt(100))))


### PR DESCRIPTION
Hi!
While working on `zio-cli` `Options`, I discovered a refactoring to simplify options parsing.
The commit removes the unused `Options.recognizes` method. It also refactors the `Options.foldSingle` and `Options.support` methods into a more compact version in the `Options.Single` subtype.
I've also added a test case for `CliConfig` configured in case sensitive mode.
Hope this is useful!