### PR TITLE
Improved validation

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -52,7 +52,7 @@ object Command {
       args: List[String],
       conf: CliConfig
     ): IO[Option[HelpDoc], CommandDirective[(OptionsType, ArgsType)]] =
-      builtInOptions.validate(args, conf).map(_._2).some.map(CommandDirective.BuiltIn(_))
+      builtInOptions.validate(args, conf).bimap(_.error, _._2).some.map(CommandDirective.BuiltIn(_))
 
     def completions(shellType: ShellType): Set[List[String]] = ???
 
@@ -97,7 +97,7 @@ object Command {
       conf: CliConfig
     ): IO[HelpDoc, CommandDirective[(OptionsType, ArgsType)]] =
       for {
-        tuple               <- self.options.validate(args, conf)
+        tuple               <- self.options.validate(args, conf).mapError(_.error)
         (args, optionsType) = tuple
         tuple               <- self.args.validate(args, conf)
         (args, argsType)    = tuple

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -24,16 +24,6 @@ import zio.cli.HelpDoc.Span._
 
 import scala.collection.immutable.Nil
 
-final case class ValidationError(validationErrorType: ValidationErrorType, error: HelpDoc) {
-  def isOptionMissing: Boolean = validationErrorType == ValidationErrorType.MissingValue
-}
-
-sealed trait ValidationErrorType
-object ValidationErrorType {
-  case object InvalidValue extends ValidationErrorType
-  case object MissingValue extends ValidationErrorType
-}
-
 /**
  * A `Flag[A]` models a command-line flag that produces a value of type `A`.
  */

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -1,0 +1,11 @@
+package zio.cli
+
+final case class ValidationError(validationErrorType: ValidationErrorType, error: HelpDoc) {
+  def isOptionMissing: Boolean = validationErrorType == ValidationErrorType.MissingValue
+}
+
+sealed trait ValidationErrorType
+object ValidationErrorType {
+  case object InvalidValue extends ValidationErrorType
+  case object MissingValue extends ValidationErrorType
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -65,6 +65,11 @@ object OptionsSpec extends DefaultRunnableSpec {
       val r = f.validate(List("--firstname"), CliConfig.default)
       assertM(r.either)(isLeft)
     },
+    testM("validate invalid option using withDefault") {
+      val o = Options.integer("integer").withDefault(BigInt(0), "0 as default")
+      val r = o.validate(List("--integer", "abc"), CliConfig.default)
+      assertM(r.either)(isLeft)
+    },
     testM("validate case sensitive CLI config") {
       val caseSensitiveConfig = CliConfig(true, 2)
       val f: Options[String]  = Options.text("Firstname").alias("F")
@@ -244,6 +249,11 @@ object OptionsSpec extends DefaultRunnableSpec {
       testM("test orElse with no options given") {
         val o = Options.text("string") | Options.integer("integer")
         val r = o.validate(Nil, CliConfig.default)
+        assertM(r.either)(isLeft)
+      },
+      testM("validate invalid option in OrElse option when using withDefault") {
+        val o = (Options.integer("min") | Options.integer("max")).withDefault(BigInt(0), "0 as default")
+        val r = o.validate(List("--min", "abc"), CliConfig.default)
         assertM(r.either)(isLeft)
       }
     ),


### PR DESCRIPTION
Hi!
I discovered a new test case involving default values, which fails using the current implementation:
```
testM("validate invalid option using withDefault") {
  val o = Options.integer("integer").withDefault(BigInt(0), "0 as default")
  val r = o.validate(List("--integer", "abc"), CliConfig.default)
  assertM(r.either)(isLeft)
}
```
The problem is that `withDefault` currently absorbs all errors from previous validations,
instead of only recovering a "missing option".
This pull request contains some work John and I discussed using direct messaging. The idea is
to make `Options.validate` also return the nature of the error together with the help documentation.
Hope this helps!