### PR TITLE
Fix default value in help doc

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -231,7 +231,7 @@ object Options {
       options.helpDoc.mapDescriptionList {
         case (span, block) =>
           span -> (block + HelpDoc.p(
-            s"This setting is optional. If unspecified, the default value of this option is ${defaultDescription}."
+            s"This setting is optional. If unspecified, the default value of this option is ${default}. ${defaultDescription}"
           ))
       }
 


### PR DESCRIPTION
Fix a typo that excluded the default value from appearing in the help description. 