### PR TITLE
Subcommands

### DIFF
--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.6-15-209c2a5c")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.6-15-209c2a5c")

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -6,6 +6,9 @@ final case class ValidationError(validationErrorType: ValidationErrorType, error
 
 sealed trait ValidationErrorType
 object ValidationErrorType {
-  case object InvalidValue extends ValidationErrorType
-  case object MissingValue extends ValidationErrorType
+  case object InvalidValue      extends ValidationErrorType
+  case object MissingValue      extends ValidationErrorType
+  case object CommandMismatch   extends ValidationErrorType
+  case object MissingSubCommand extends ValidationErrorType
+  case object InvalidArgument   extends ValidationErrorType
 }

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -8,25 +8,41 @@ import zio.cli.HelpDoc.Span.error
 import scala.language.postfixOps
 
 object CommandSpec extends DefaultRunnableSpec {
+
   def spec = suite("Command Spec")(
     suite("Toplevel Command Spec")(
       suite("Command with options followed by args")(
         testM("Should validate successfully") {
-          assertM(Tail.command.parse(List("-n", "100", "foo.log"), CliConfig.default))(
+          assertM(Tail.command.parse(List("tail", "-n", "100", "foo.log"), CliConfig.default))(
             equalTo(CommandDirective.UserDefined(List.empty[String], (BigInt(100), "foo.log")))
           ) *>
-            assertM(Ag.command.parse(List("--after", "2", "--before", "3", "fooBar"), CliConfig.default))(
+            assertM(Ag.command.parse(List("grep", "--after", "2", "--before", "3", "fooBar"), CliConfig.default))(
               equalTo(CommandDirective.UserDefined(List.empty[String], ((BigInt(2), BigInt(3)), "fooBar")))
             )
         },
         testM("Should provide auto correct suggestions for misspelled options") {
-          assertM(Ag.command.parse(List("--afte", "2", "--before", "3", "fooBar"), CliConfig.default).either)(
+          assertM(
+            Ag.command
+              .parse(List("grep", "--afte", "2", "--before", "3", "fooBar"), CliConfig.default)
+              .either
+              .map(_.left.map(_.error))
+          )(
             equalTo(Left(p(error("""The flag "--afte" is not recognized. Did you mean --after?"""))))
           ) *>
-            assertM(Ag.command.parse(List("--after", "2", "--efore", "3", "fooBar"), CliConfig.default).either)(
+            assertM(
+              Ag.command
+                .parse(List("grep", "--after", "2", "--efore", "3", "fooBar"), CliConfig.default)
+                .either
+                .map(_.left.map(_.error))
+            )(
               equalTo(Left(p(error("""The flag "--efore" is not recognized. Did you mean --before?"""))))
             ) *>
-            assertM(Ag.command.parse(List("--afte", "2", "--efore", "3", "fooBar"), CliConfig.default).either)(
+            assertM(
+              Ag.command
+                .parse(List("grep", "--afte", "2", "--efore", "3", "fooBar"), CliConfig.default)
+                .either
+                .map(_.left.map(_.error))
+            )(
               equalTo(
                 Left(
                   Sequence(
@@ -38,11 +54,94 @@ object CommandSpec extends DefaultRunnableSpec {
             )
         },
         testM("Shows an error if an option is missing") {
-          assertM(Ag.command.parse(List("--a", "2", "--before", "3", "fooBar"), CliConfig.default).either)(
+          assertM(
+            Ag.command
+              .parse(List("grep", "--a", "2", "--before", "3", "fooBar"), CliConfig.default)
+              .either
+              .map(_.left.map(_.error))
+          )(
             equalTo(Left(p(error("Expected to find --after option."))))
           )
         }
       )
+    ),
+    suite("test commands joined by | operator")(
+      testM("") {
+        val orElseCommand =
+          Command("remote", Options.Empty, Args.none) | Command("log", Options.Empty, Args.none)
+
+        assertM(orElseCommand.parse(List("log"), CliConfig.default))(
+          equalTo(CommandDirective.UserDefined(Nil, ((), ())))
+        )
+      }
+    ),
+    suite("SubCommand Suite")(
+      suite("having two sub commands without options or arguments")({
+
+        val git =
+          Command("git", Options.Empty, Args.none).subcommands(
+            Command("remote", Options.Empty, Args.none),
+            Command("log", Options.Empty, Args.none)
+          )
+
+        Vector(
+          testM("match first sub command without any surplus arguments") {
+            assertM(git.parse(List("git", "remote"), CliConfig.default))(
+              equalTo(CommandDirective.UserDefined(Nil, (((), ()), ((), ()))))
+            )
+          },
+          testM("match first sub command with a surplus options") {
+            assertM(git.parse(List("git", "remote", "-v"), CliConfig.default))(
+              equalTo(CommandDirective.UserDefined(List("-v"), (((), ()), ((), ()))))
+            )
+          },
+          testM("match second sub command without any surplus arguments") {
+            assertM(git.parse(List("git", "log"), CliConfig.default))(
+              equalTo(CommandDirective.UserDefined(Nil, (((), ()), ((), ()))))
+            )
+          }
+        )
+      }: _*),
+      suite("sub command usage with options and arguments")({
+
+        val git =
+          Command("git", Options.Empty, Args.none).subcommands(
+            Command("rebase", Options.bool("i", true), Args.text ++ Args.text)
+          )
+
+        Vector(
+          testM("test sub command with options and arguments") {
+            assertM(git.parse(List("git", "rebase", "-i", "upstream", "branch"), CliConfig.default))(
+              equalTo(CommandDirective.UserDefined(Nil, (((), ()), (true, ("upstream", "branch")))))
+            )
+          },
+          testM("test unknown sub command") {
+            assertM(git.parse(List("git", "abc"), CliConfig.default).flip.map(_.validationErrorType))(
+              equalTo(ValidationErrorType.CommandMismatch)
+            )
+          },
+          testM("test without sub command") {
+            assertM(git.parse(List("git"), CliConfig.default).flip.map(_.validationErrorType))(
+              equalTo(ValidationErrorType.MissingSubCommand)
+            )
+          }
+        )
+      }: _*),
+      suite("test sub sub commands") {
+
+        val command =
+          Command("command", Options.Empty, Args.none).subcommands(
+            Command("sub", Options.Empty, Args.none).subcommands(
+              Command("subsub", Options.bool("i", true), Args.text)
+            )
+          )
+
+        testM("sub sub command with option and argument")(
+          assertM(command.parse(List("command", "sub", "subsub", "-i", "text"), CliConfig.default))(
+            equalTo(CommandDirective.UserDefined(Nil, (((), ()), (((), ()), (true, "text")))))
+          )
+        )
+      }
     )
   )
 


### PR DESCRIPTION
Hi all!
This pull request tries to improve the processing of sub-commands in `zio-cli` mentioned in issuer #84.
The command parsing now also uses `ValidationError` for fine-grained parsing.
A couple of new tests check the correctness of sub-command parsing.
I also removed the `metals.sbt` files.
Hope this is useful!