### PR TITLE
#72: Added Options.map to support property arguments -> Options[Map[String, String]]

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -544,4 +544,62 @@ object Options {
   def zoneOffset(name: String): Options[JZoneOffset] =
     Single(name, Vector.empty, PrimType.ZoneOffset)
 
+  /**
+   * Creates a property flag with the specified name.
+   * Property arguments may be repeated several times (-D key1=value -D key2=value)
+   * or specifying all key/values in one argument (-D key1=value key2=value).
+   */
+  def map(name: String): Options[Predef.Map[String, String]] =
+    map(Options.Single(name, Vector.empty, PrimType.Text))
+
+  /**
+   * Creates a property flag with from an argument option as Options.single.
+   */
+  def map(argumentOption: Options.Single[String]): Options[Predef.Map[String, String]] = {
+    // argument name
+    val argumentName = argumentOption.name
+
+    new Options[Predef.Map[String, String]] { self =>
+      override def helpDoc: HelpDoc = argumentOption.helpDoc
+
+      override def synopsis: UsageSynopsis = argumentOption.synopsis
+
+      override def uid: Option[String] = argumentOption.uid
+
+      private def createMapEntry(input: String) = {
+        val Array(a, b) = input.split("=").take(2)
+        a -> b
+      }
+
+      private def createMapFromStringList(input: List[String]) =
+        input.filter(!_.startsWith("-")).map(createMapEntry).toMap
+
+      private def makeFullName(s: String): String = (if (s.length == 1) "-" else "--") + s
+
+      private def fullName: String = makeFullName(argumentName)
+
+      private val argumentNames = fullName :: argumentOption.aliases.map(makeFullName).toList
+
+      private def supports(s: String, conf: CliConfig): Boolean =
+        if (conf.caseSensitive)
+          argumentNames.contains(s)
+        else
+          argumentNames.exists(_.equalsIgnoreCase(s))
+
+      private def processArguments(input: List[String], first: String, conf: CliConfig) = {
+        val r = input.span(s => !s.startsWith("-") || supports(s, conf))
+        (r._2, createMapFromStringList(r._1) + createMapEntry(first))
+      }
+
+      override def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], Predef.Map[String, String])] = {
+        for {
+          n <- argumentOption.validate(args, conf)
+        } yield processArguments(n._1, n._2, conf)
+      }
+
+      override private[cli] def modifySingle(f: SingleModifier) = {
+        Options.map(f(argumentOption))
+      }
+    }
+  }
 }

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -15,6 +15,7 @@ object OptionsSpec extends DefaultRunnableSpec {
   val a: Options[BigInt]            = Options.integer("age")
   val aOpt: Options[Option[BigInt]] = Options.integer("age").optional("N/A")
   val b: Options[Boolean]           = Options.bool("verbose", true)
+  val m: Options[Map[String, String]] = Options.map(name="defs").alias("d")
 
   val options = f ++ l ++ a
 
@@ -308,6 +309,29 @@ object OptionsSpec extends DefaultRunnableSpec {
       assertM(r.either)(
         equalTo(Left(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --age option.")))))
       )
-    }
+    },
+    suite("property arguments")(
+      testM("validate missing option") {
+        val r = m.validate(List(), CliConfig.default)
+        assertM(r.run)(
+          fails(equalTo(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --defs option.")))))
+        )
+      },
+      testM("validate repeated values") {
+        val r = m.validate(List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
+
+        assertM(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
+      },
+      testM("validate different key/values with alias") {
+        val r = m.validate(List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+
+        assertM(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
+      },
+      testM("validate different key/values") {
+        val r = m.validate(List("--defs", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+
+        assertM(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
+      },
+    ),
   )
 }


### PR DESCRIPTION
Created a Options.map function that returns an Options[Map[String, String]] instance to parse property args.
Created a suite test ("property arguments") in Options spec for this feature.

I think that this is the simplest solution to support property arguments as Map[String, String] values.
I have doubts about:

1. Create a separate class to support this feature (Options.Map) but I'm confused with the current Options.Map final case class (that I think is used now to support map function in Options trait)
2. Think about the need to create both key and value typed property args (Map[A, B] instead of Map[String, String])