### PR TITLE
 #73: Support displaying help pages for subcommands

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -87,7 +87,16 @@ object Command {
       args: List[String],
       conf: CliConfig
     ): IO[ValidationError, CommandDirective[(OptionsType, ArgsType)]] =
-      builtIn(args, conf) orElse userDefined(args, conf)
+      parseBuiltInArgs(args, conf) orElse userDefined(args, conf)
+
+    def parseBuiltInArgs(
+      args: List[String],
+      conf: CliConfig
+    ): IO[Option[HelpDoc], CommandDirective[(OptionsType, ArgsType)]] =
+      if (args.headOption.map(conf.normalizeCase(_) == conf.normalizeCase(name)).getOrElse(false))
+        builtIn(args, conf)
+      else
+        IO.fail(None)
 
     def synopsis: UsageSynopsis =
       UsageSynopsis.Named(name, None) + options.synopsis + args.synopsis
@@ -190,7 +199,24 @@ object Command {
           case CommandDirective.BuiltIn(x) =>
             x match {
               case BuiltInOption.ShowHelp(_) =>
-                ZIO.succeed(CommandDirective.builtIn(BuiltInOption.ShowHelp(self.helpDoc)))
+                for {
+                  help <- (child.parse(args.tail, conf) orElse ZIO.succeed(
+                            CommandDirective.builtIn(BuiltInOption.ShowHelp(self.helpDoc))
+                          ))
+                  help <- help match {
+                            case CommandDirective.BuiltIn(BuiltInOption.ShowHelp(h)) => IO.succeed(h)
+                            case _ =>
+                              IO.fail(
+                                ValidationError(
+                                  ValidationErrorType.InvalidArgument,
+                                  HelpDoc.empty
+                                )
+                              )
+                          }
+                } yield {
+                  CommandDirective.builtIn(BuiltInOption.ShowHelp(help))
+                }
+
               case x => ZIO.succeed(CommandDirective.builtIn(x))
             }
 


### PR DESCRIPTION
Changes to allow subcommands respond to builtin options (like --help):

Main changes are as follows:
1. Create  SingleCommand parseBuiltInArgs method to parse builtInArgs only if the command name matches.
2. Subcommands parse:
    Try to parse subcommand (child) args first orElse parent ones
    ```scala
       (child.parse(args.tail, conf) orElse ZIO.succeed(
               CommandDirective.builtIn(BuiltInOption.ShowHelp(self.helpDoc))
        ))
    ```
Next screenshot shows 'git add --help' behavior:
![image](https://user-images.githubusercontent.com/11801/134573995-78bda898-7307-4979-8652-2110398e6871.png)
