### PR TITLE
Auto-generate Bash scripts and Bash/program interface for CLI tab completion

### DIFF
--- a/docs/overview/bash_and_zsh_completion.md
+++ b/docs/overview/bash_and_zsh_completion.md
@@ -1,0 +1,74 @@
+---
+id: bash_and_zsh_completion
+title: "Bash and Zsh Completion"
+---
+
+## Overview
+`zio-cli` supports a mechanism for performing tab completion of command line
+options and arguments in bash and zsh. The approach that `zio-cli` uses to
+communicate with the shell tooling for performing tab completion is heavily
+inspired by the excellent Haskell
+[optparse-applicative](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions)
+library. Every `CliApp` is extended with a few hidden built-in options for
+providing tab completions to shell environments.
+
+In what follows, pretend that your CLI application (called `my-cli-app`) has been
+installed into a stable location in your path (such as the `~/.local/bin`
+directory favored by the `zio-cli` installer script).
+
+## Generating a completion shell script
+The `--shell-completion-script` and `--shell-type` built-in options produce a
+shell script that enables tab completion. In the example below, we generate a
+completion script (called `completion-script.sh`):
+```bash
+my-cli-app                                       \
+    --shell-completion-script `which my-cli-app` \
+    --shell-type bash > completion-script.sh
+```
+After generating the script, you can quickly enable tab completion via:
+```bash
+source completion-script.sh
+```
+Unfortunately, the tab completion will only be enabled within the current shell
+session. Normally, the output of `--shell-completion-script` should be shipped
+with the program and copied to the appropriate directory (e.g.,
+`/etc/bash_completion.d/`) during program installation.
+
+## How Bash and Zsh Completions are Generated
+The shell completion scripts register an event handler that fires whenever
+`my-cli-app` is the first term at the terminal prompt and the tab key is
+pressed. This event handler sends information about the terminal contents and
+cursor position back to `my-cli-app` using another built-in option called
+`--shell-completion-index` and some special environment variables
+(`COMP_WORD_0`, `COMP_WORD_1`, ...).
+
+When `my-cli-app` receives these values, it runs a completion algorithm and
+prints the completion terms to the console (one line per completion term). The
+console output feeds back into the shell machinery, which renders the completion
+results in the terminal.
+
+For example, when the user types the following in the terminal
+```
+$ my-cli-app foo bar baz
+```
+and then moves the cursor over "foo" and hits the tab key, `my-cli-app` is called
+as follows:
+```bash
+COMP_WORD_0=my-cli-app     \
+COMP_WORD_1=foo            \
+COMP_WORD_2=bar            \
+COMP_WORD_3=baz            \
+my-cli-app                 \
+--shell-completion-index 1 \
+--shell-type bash
+```
+
+The `COMP_WORD_` prefix of these environment variables is directly inspired by
+the `COMP_WORD` array-valued Bash variable that is part of its
+[programmable completion system](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html).
+Unfortunately, array-valued variables cannot be used as environment variables,
+so our approach instead uses one variable per term in the array.
+
+## Further Reading
+The [optparse-applicative documentation](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions)
+is an excellent resource that may help to clarify the implementation above.

--- a/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
@@ -1,19 +1,32 @@
 package zio.cli
 
-sealed trait BuiltInOption
+import java.nio.file.{Path => JPath}
+
+sealed trait BuiltInOption extends Product with Serializable
 object BuiltInOption {
-  final case class ShowHelp(helpDoc: HelpDoc)                      extends BuiltInOption
-  final case class ShowCompletions(completions: Set[List[String]]) extends BuiltInOption
+  final case class ShowHelp(helpDoc: HelpDoc) extends BuiltInOption
+  final case class ShowCompletionScript(pathToExecutable: JPath, shellType: ShellType) extends BuiltInOption
+  final case class ShowCompletions(index: Int, shellType: ShellType) extends BuiltInOption
 
-  final case class BuiltIn(help: Boolean, shellCompletions: Option[ShellType])
+  final case class BuiltIn(
+    help: Boolean,
+    shellCompletionScriptPath: Option[JPath],
+    shellType: Option[ShellType],
+    shellCompletionIndex: Option[Int]
+  )
 
-  lazy val builtInOptions: Options[BuiltIn] =
-    (Options.boolean("help") ++ ShellType.option.optional("N/A")).as(BuiltIn)
+  lazy val builtInOptions = (
+    Options.boolean("help") ++
+    Options.file("shell-completion-script").optional("N/A") ++
+    ShellType.option.optional("N/A") ++
+    Options.integer("shell-completion-index").map(_.toInt).optional("N/A")
+  ).as(BuiltIn)
 
-  def builtInOptions(helpDoc: => HelpDoc, completions: ShellType => Set[List[String]]): Options[Option[BuiltInOption]] =
+  def builtInOptions(helpDoc: => HelpDoc): Options[Option[BuiltInOption]] =
     builtInOptions.map {
-      case BuiltIn(true, _)            => Some(ShowHelp(helpDoc))
-      case BuiltIn(_, Some(shellType)) => Some(ShowCompletions(completions(shellType)))
-      case _                           => None
+      case BuiltIn(true, _, _, _)                      => Some(ShowHelp(helpDoc))
+      case BuiltIn(_, Some(path), Some(shellType), _)  => Some(ShowCompletionScript(path, shellType))
+      case BuiltIn(_, _, Some(shellType), Some(index)) => Some(ShowCompletions(index, shellType))
+      case _                                           => None
     }
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/BuiltInOption.scala
@@ -4,9 +4,9 @@ import java.nio.file.{Path => JPath}
 
 sealed trait BuiltInOption extends Product with Serializable
 object BuiltInOption {
-  final case class ShowHelp(helpDoc: HelpDoc) extends BuiltInOption
+  final case class ShowHelp(helpDoc: HelpDoc)                                          extends BuiltInOption
   final case class ShowCompletionScript(pathToExecutable: JPath, shellType: ShellType) extends BuiltInOption
-  final case class ShowCompletions(index: Int, shellType: ShellType) extends BuiltInOption
+  final case class ShowCompletions(index: Int, shellType: ShellType)                   extends BuiltInOption
 
   final case class BuiltIn(
     help: Boolean,
@@ -17,9 +17,9 @@ object BuiltInOption {
 
   lazy val builtInOptions = (
     Options.boolean("help") ++
-    Options.file("shell-completion-script").optional("N/A") ++
-    ShellType.option.optional("N/A") ++
-    Options.integer("shell-completion-index").map(_.toInt).optional("N/A")
+      Options.file("shell-completion-script").optional("N/A") ++
+      ShellType.option.optional("N/A") ++
+      Options.integer("shell-completion-index").map(_.toInt).optional("N/A")
   ).as(BuiltIn)
 
   def builtInOptions(helpDoc: => HelpDoc): Options[Option[BuiltInOption]] =

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -67,9 +67,9 @@ object CliApp {
         case ShowCompletionScript(path, shellType) =>
           putStrLn(CompletionScript(path, if (command.names.nonEmpty) command.names else Set(name), shellType))
         case ShowCompletions(index, shellType) =>
-          envs.flatMap{ envMap =>
-            val compWords = envMap.collect{
-              case (s"COMP_WORD_$idx", word) => (idx.toInt, word)
+          envs.flatMap { envMap =>
+            val compWords = envMap.collect { case (s"COMP_WORD_$idx", word) =>
+              (idx.toInt, word)
             }.toList.sortBy(_._1).map(_._2)
 
             val completions = Completion.complete(shellType, compWords, index)

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -6,6 +6,7 @@ import zio.console._
 import zio.cli.HelpDoc.{h1, p}
 import zio.cli.HelpDoc.Span.{code, text}
 import zio.cli.BuiltInOption._
+import zio.system._
 
 import scala.annotation.tailrec
 
@@ -14,7 +15,7 @@ import scala.annotation.tailrec
  * requires environment `R`, and may fail with a value of type `E`.
  */
 sealed trait CliApp[-R, +E, Model] {
-  def run(args: List[String]): ZIO[R with Console, Nothing, ExitCode]
+  def run(args: List[String]): ZIO[R with Console with System, Nothing, ExitCode]
 
   def config(newConfig: CliConfig): CliApp[R, E, Model]
 
@@ -50,7 +51,7 @@ object CliApp {
   ) extends CliApp[R, E, Model] { self =>
     def config(newConfig: CliConfig): CliApp[R, E, Model] = copy(config = newConfig)
 
-    def executeBuiltIn(builtInOption: BuiltInOption): RIO[Console, Unit] =
+    def executeBuiltIn(builtInOption: BuiltInOption): RIO[Console with System, Unit] =
       builtInOption match {
         case ShowHelp(helpDoc) =>
           val fancyName =
@@ -63,8 +64,17 @@ object CliApp {
 
           putStrLn((header + fancyName + synopsis + helpDoc + footer).toPlaintext(80))
 
-        case ShowCompletions(completions) =>
-          putStrLn(completions.map(_.mkString(" ")).mkString("\n"))
+        case ShowCompletionScript(path, shellType) =>
+          putStrLn(CompletionScript(path, if (command.names.nonEmpty) command.names else Set(name), shellType))
+        case ShowCompletions(index, shellType) =>
+          envs.flatMap{ envMap =>
+            val compWords = envMap.collect{
+              case (s"COMP_WORD_$idx", word) => (idx.toInt, word)
+            }.toList.sortBy(_._1).map(_._2)
+
+            val completions = Completion.complete(shellType, compWords, index)
+            ZIO.foreach_(completions)(word => putStrLn(word))
+          }
       }
 
     def footer(newFooter: HelpDoc): CliApp[R, E, Model] =
@@ -83,7 +93,7 @@ object CliApp {
         case Command.Subcommands(parent, _) => prefix(parent)
       }
 
-    def run(args: List[String]): ZIO[R with Console, Nothing, ExitCode] =
+    def run(args: List[String]): ZIO[R with Console with System, Nothing, ExitCode] =
       command
         .parse(prefix(command) ++ args, config)
         .foldM(

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -47,15 +47,13 @@ object Command {
      * Built-in options supported by the command, such as "--help".
      */
     lazy val builtInOptions: Options[Option[BuiltInOption]] =
-      BuiltInOption.builtInOptions(helpDoc, completions(_))
+      BuiltInOption.builtInOptions(helpDoc)
 
     def builtIn(
       args: List[String],
       conf: CliConfig
     ): IO[Option[HelpDoc], CommandDirective[(OptionsType, ArgsType)]] =
       builtInOptions.validate(args, conf).mapBoth(_.error, _._2).some.map(CommandDirective.BuiltIn(_))
-
-    def completions(shellType: ShellType): Set[List[String]] = ???
 
     def helpDoc: HelpDoc = {
       val descriptionsSection = {

--- a/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
@@ -1,0 +1,15 @@
+package zio.cli
+
+object Completion {
+  def complete(shellType: ShellType, words: List[String], index: Int): List[String] = {
+    // TODO: The dummy completions below are just a proof of concept. They
+    // should be replated with legitimate completions.
+    val dummyCompletions = (
+      words.zipWithIndex.map{case (word, i) => s"$word-$i"} ++
+      List(s"cursor-index-$index") ++
+      List(s"shell-is-$shellType") ++
+      "Mini-Me You Complete Me".split(" ").toList
+    )
+    dummyCompletions
+  }
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
@@ -3,7 +3,7 @@ package zio.cli
 object Completion {
   def complete(shellType: ShellType, words: List[String], index: Int): List[String] = {
     // TODO: The dummy completions below are just a proof of concept. They
-    // should be replated with legitimate completions.
+    // should be replaced with legitimate completions.
     val dummyCompletions = (
       words.zipWithIndex.map{case (word, i) => s"$word-$i"} ++
       List(s"cursor-index-$index") ++

--- a/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Completion.scala
@@ -5,10 +5,10 @@ object Completion {
     // TODO: The dummy completions below are just a proof of concept. They
     // should be replaced with legitimate completions.
     val dummyCompletions = (
-      words.zipWithIndex.map{case (word, i) => s"$word-$i"} ++
-      List(s"cursor-index-$index") ++
-      List(s"shell-is-$shellType") ++
-      "Mini-Me You Complete Me".split(" ").toList
+      words.zipWithIndex.map { case (word, i) => s"$word-$i" } ++
+        List(s"cursor-index-$index") ++
+        List(s"shell-is-$shellType") ++
+        "Mini-Me You Complete Me".split(" ").toList
     )
     dummyCompletions
   }

--- a/zio-cli/shared/src/main/scala/zio/cli/CompletionScript.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CompletionScript.scala
@@ -1,0 +1,34 @@
+package zio.cli
+import zio.cli.ShellType.Bash
+import zio.cli.ShellType.ZShell
+import java.nio.file.{Path => JPath}
+
+object CompletionScript {
+  def apply(pathToExecutable: JPath, programNames: Set[String], shellType: ShellType): String = shellType match {
+    case Bash => bash(pathToExecutable, programNames)
+    case ZShell => ???
+  }
+  private[this] def bash(pathToExecutable: JPath, programNames: Set[String]): String = 
+    s"""|#/usr/bin/env bash
+        |_${programNames.head}()
+        |{
+        |  local CMDLINE
+        |  local IFS=$$'\\n'
+        |  CMDLINE=(--shell-type bash --shell-completion-index $$COMP_CWORD)
+        |  
+        |  INDEX=0
+        |  for arg in $${COMP_WORDS[@]}; do
+        |    export COMP_WORD_$$INDEX=$${arg}
+        |    (( INDEX++ ))
+        |  done
+        |
+        |  COMPREPLY=( $$($pathToExecutable \"$${CMDLINE[@]}\") )
+        |
+        |  # Unset the environment variables.
+        |  unset $$(compgen -v | grep "^COMP_WORD_")
+        |}
+        |
+        |""".stripMargin + programNames.map(programName =>
+          s"complete -F _${programNames.head} $programName"
+        ).mkString(System.lineSeparator)
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/CompletionScript.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CompletionScript.scala
@@ -5,10 +5,10 @@ import java.nio.file.{Path => JPath}
 
 object CompletionScript {
   def apply(pathToExecutable: JPath, programNames: Set[String], shellType: ShellType): String = shellType match {
-    case Bash => bash(pathToExecutable, programNames)
+    case Bash   => bash(pathToExecutable, programNames)
     case ZShell => ???
   }
-  private[this] def bash(pathToExecutable: JPath, programNames: Set[String]): String = 
+  private[this] def bash(pathToExecutable: JPath, programNames: Set[String]): String =
     s"""|#/usr/bin/env bash
         |_${programNames.head}()
         |{
@@ -28,7 +28,7 @@ object CompletionScript {
         |  unset $$(compgen -v | grep "^COMP_WORD_")
         |}
         |
-        |""".stripMargin + programNames.map(programName =>
-          s"complete -F _${programNames.head} $programName"
-        ).mkString(System.lineSeparator)
+        |""".stripMargin + programNames
+      .map(programName => s"complete -F _${programNames.head} $programName")
+      .mkString(System.lineSeparator)
 }


### PR DESCRIPTION
# Overview
This PR adds a mechanism for performing tab completion of command line options and arguments in bash and zsh. This approach was heavily inspired by the tab completion plumbing used in the excellent Haskell [optparse-applicative](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions) library.

Every `CliApp` is extended with a few hidden built-in options for providing tab completions to shell environments.

# How It Works
In what follows, pretend that your CLI application (called `my-cli-app`) has been installed into a stable location in your path (such as the `~/.local/bin` directory) favored by the `zio-cli` installer script.

## Generating a completion shell script
The `--shell-completion-script` and `--shell-type` built-in options produce a shell script that enables tab completion. In the example below, we generate a completion script (called `completion-script.sh`):
```bash
my-cli-app                                       \
    --shell-completion-script `which my-cli-app` \
    --shell-type bash > completion-script.sh
```
After generating the script, you can quickly enable tab completion via:
```bash
source completion-script.sh
```
Unfortunately, the tab completion will only be enabled within the current shell session. Normally, the output of `--shell-completion-script` should be shipped with the program and copied to the appropriate directory (e.g., `/etc/bash_completion.d/`) during program installation.

## How Bash and Zsh Completions are Generated
The shell completion scripts register an event handler that fires whenever `my-cli-app` is the first term at the terminal prompt and the tab key is pressed. This event handler sends information about the terminal contents and cursor position back to `my-cli-app` using another built-in option called `--shell-completion-index` and some special environment variables (`COMP_WORD_0`, `COMP_WORD_1`, ...).

When `my-cli-app` receives these values, it runs a completion algorithm and prints the completion terms to the console (one line per completion term). The console output feeds back into the shell machinery, which renders the completion
results in the terminal.

For example, when the user types the following in the terminal
```
$ my-cli-app foo bar baz
```
and then moves the cursor over "foo" and hits the tab key, `my-cli-app` is called as follows:
```bash
COMP_WORD_0=my-cli-app     \
COMP_WORD_1=foo            \
COMP_WORD_2=bar            \
COMP_WORD_3=baz            \
my-cli-app                 \
--shell-completion-index 1 \
--shell-type bash
```

The `COMP_WORD_` prefix of these environment variables is directly inspired by the `COMP_WORD` array-valued Bash variable that is part of its [programmable completion system](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html). Unfortunately, array-valued variables cannot be used as environment variables, so our approach instead uses one variable per term in the array.

A notable difference between `zio-cli` and Haskell's `optparse-applicative`: The `optparse-applicative` library sends these words to the user's program via multiple repeating `--bash-completion-word` CLI options. Unfortunately, I was not able to get that to work with `zio-cli`, so in the interest of time I sidestepped the issue and went with environment variables instead.

## Further Reading
The [optparse-applicative documentation](https://github.com/pcapriotti/optparse-applicative#bash-zsh-and-fish-completions) is an excellent resource that may help to clarify the implementation above.

## Future Work for Future PRs
- These "hidden" built-ins are not actually hidden: They appear in the `--help` messages. A mechanism to toggle the visibility of options should be considered. Or, maybe these hidden built-ins should be masked out of the help messages as a special case.
- Zsh support should be added.
- The `zio-cli` `sbt` plugin should be modified to do something with the completion scripts. I wasn't aware that the plugin existed until the very end of the hackathon, so I ran out of time to hook it up.
- Unit test coverage would be nice. Normally I'd start there and do test-driven development, but making sure that the shell/program communication actually worked was more important on my end.
- Replace the dummy completion method with a real one.

