### PR TITLE
Fix bug that cause ambiguous implicits in Scala 3 in certain usecases

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Reducable.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Reducable.scala
@@ -5,27 +5,24 @@ trait Reducable[-A, -B] {
   def fromTuple2(t: (A, B)): Out
 }
 
-object Reducable extends ReducableLowPriority {
+object Reducable extends ReducableLowPriority1 {
 
   type Aux[A, B, C] = Reducable[A, B] { type Out = C }
 
-  implicit def unitRight[A]: Reducable.Aux[A, Unit, A] = new Reducable[A, Unit] {
-    override type Out = A
-    override def fromTuple2(t: (A, Unit)): A = t._1
-  }
-
-  implicit def unitLeft[A]: Reducable.Aux[Unit, A, A] = new Reducable[Unit, A] {
+  implicit def ReducableLeftIdentity[A]: Reducable.Aux[Unit, A, A] = new Reducable[Unit, A] {
     override type Out = A
     override def fromTuple2(t: (Unit, A)): A = t._2
   }
+}
 
-  implicit val unitBoth: Reducable.Aux[Unit, Unit, Unit] = new Reducable[Unit, Unit] {
-    override type Out = Unit
-    override def fromTuple2(t: (Unit, Unit)): Unit = ()
+trait ReducableLowPriority1 extends ReducableLowPriority2 {
+  implicit def ReducableRightIdentity[A]: Reducable.Aux[A, Unit, A] = new Reducable[A, Unit] {
+    override type Out = A
+    override def fromTuple2(t: (A, Unit)): A = t._1
   }
 }
 
-trait ReducableLowPriority {
+trait ReducableLowPriority2 {
   implicit def tuple[A, B]: Reducable.Aux[A, B, (A, B)] = new Reducable[A, B] {
     override type Out = (A, B)
     override def fromTuple2(t: (A, B)): (A, B) = t


### PR DESCRIPTION
Implementations of `Reducable` being in the same implicit scope caused issues at use sites. 

This fixes that by using the "priorities" pattern.