### PR TITLE
Upgrade ZIO to 2.0.0-RC4 + resurrect word count example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion = "2.0.0-RC3"
+val zioVersion = "2.0.0-RC4"
 
 lazy val root = project
   .in(file("."))

--- a/examples/shared/src/main/scala/zio/cli/examples/GitExample.scala
+++ b/examples/shared/src/main/scala/zio/cli/examples/GitExample.scala
@@ -6,7 +6,6 @@ import java.nio.file.{Path => JPath}
 import zio.cli.{Args, CliApp, Command, Exists, HelpDoc, Options}
 import zio.cli.HelpDoc.Span.text
 
-//import zio._
 import zio.ZIOAppDefault
 import zio.Console.printLine
 

--- a/zio-cli/shared/src/test/scala/zio/cli/PrimTypeSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/PrimTypeSpec.scala
@@ -141,7 +141,7 @@ object PrimTypeSpec extends ZIOSpecDefault {
     simplePrimTypeSuite(PrimType.Period, anyPeriod, "Period")
   )
 
-  def simplePrimTypeSuite[G, P[G] <: PrimType[G]](primType: P[G], gen: Gen[Random, G], primeTypeName: String) =
+  def simplePrimTypeSuite[G, P[G] <: PrimType[G]](primType: P[G], gen: Gen[Any, G], primeTypeName: String) =
     suite(s"$primeTypeName Suite")(
       test(s"validate returns proper $primeTypeName representation") {
         check(gen) { i =>
@@ -153,7 +153,7 @@ object PrimTypeSpec extends ZIOSpecDefault {
       }
     )
 
-  def randomizeCharCases(s: String): ZIO[Random, Nothing, String] =
+  def randomizeCharCases(s: String): UIO[String] =
     ZIO.foreach(s.toList)(c => Random.nextBoolean.map(b => if (b) c.toUpper else c.toLower)).map(_.mkString)
 
   def mockFileSystem(
@@ -172,13 +172,13 @@ object PrimTypeSpec extends ZIOSpecDefault {
     override def isRegularFile(path: JPath): UIO[Boolean] = ZIO.succeed(pathIsRegularFile)
   }
 
-  val anyTrueBooleanString: Gen[Random, String] =
+  val anyTrueBooleanString: Gen[Any, String] =
     Gen.fromIterable(List("true", "1", "y", "yes", "on")).mapZIO(randomizeCharCases)
-  val anyFalseBooleanString: Gen[Random, String] =
+  val anyFalseBooleanString: Gen[Any, String] =
     Gen.fromIterable(List("false", "0", "n", "no", "off")).mapZIO(randomizeCharCases)
 
-  val anyBigInt: Gen[Random, BigInt] = Gen.long(0, Long.MaxValue).map(BigInt(_))
-  val anyBoolean: Gen[Random, Boolean] =
+  val anyBigInt: Gen[Any, BigInt] = Gen.long(0, Long.MaxValue).map(BigInt(_))
+  val anyBoolean: Gen[Any, Boolean] =
     Gen.fromIterable(List(true, false))
   val anyInstant = Gen.instant.map(_.atZone(ZoneOffset.UTC))
   val anyPeriod = for {

--- a/zio-cli/shared/src/test/scala/zio/cli/completion/CompletionSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/completion/CompletionSpec.scala
@@ -10,7 +10,7 @@ import java.nio.file.{Files => JFiles, Path => JPath}
 
 import scala.language.postfixOps
 
-object CompletionSpec extends DefaultRunnableSpec {
+object CompletionSpec extends ZIOSpecDefault {
 
   /**
    * A micro potpourri of functions borrowed (in simplified form) from `zio-nio`.

--- a/zio-cli/shared/src/test/scala/zio/cli/completion/RegularLanguageSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/completion/RegularLanguageSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.cli._
 
-object RegularLanguageSpec extends DefaultRunnableSpec {
+object RegularLanguageSpec extends ZIOSpecDefault {
   def spec = suite("RegularLanguage Spec")(
     suite("Toplevel Command Completion Spec")(
       suite("Empty language")(


### PR DESCRIPTION
1. Upgrade the ZIO version to 2.0.0-RC4. Mostly this involved removing `Console` and `Random` from various environments and `Gen` generators, and changing `DefaultRunnableSpec` to `ZIOSpecDefault`.
2. Resurrect and freshen up the commented-out word count example app. There are no unit tests for it, but I was able to run it and confirm that it works on a text file.