### PR TITLE
Upgrade GraalVM version in installer.sh and some parsing fixes

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -19,7 +19,7 @@ version="VERSION"
 downloadUrl="DOWNLOAD_URL"
 
 shouldEnsureNativeImage="${ENSURE_NATIVE_IMAGE}"
-graalvmVersion="${GRAALVM_VERSION:-20.3.0}"
+graalvmVersion="${GRAALVM_VERSION:-22.3.0}"
 javaVersion="${GRAALVM_JAVA_VERSION:-java8}"
 
 xdgUsrHome="${XDG_DATA_HOME:-"$HOME/.local/share"}"
@@ -36,7 +36,7 @@ installGraalVm() {
 	if ! [ -d "${graalvmDir}" ]; then
 
 		case "$(uname -s)" in
-		Darwin*) os="mac" ;;
+		Darwin*) os="darwin" ;;
 		Linux*) os="linux" ;;
 		CYGWIN*) os="windows" ;;
 		MINGW*) os="windows" ;;
@@ -74,7 +74,7 @@ ensureCli() {
 	if ! [ -f "${versionedBin}" ]; then
 
 		if [ -n "${shouldEnsureNativeImage}" ] && ! command -v native-image >/dev/null; then
-			PATH="${PATH}:${graalvmDir}/bin"
+			PATH="${PATH}:${graalvmDir}/Contents/Home/bin"
 			installGraalVm && installNativeImage
 		fi
 
@@ -85,7 +85,7 @@ ensureCli() {
 }
 
 buildNativeImage() {
-	PATH="${PATH}:${graalvmDir}/bin"
+	PATH="${PATH}:${graalvmDir}/Contents/Home/bin"
 	export GRAALVM_HOME="${graalvmDir}"
 	cd "${appDir}/bin"
 	native-image -jar "$(basename "${versionedJar}")" "$(basename "${versionedBin}")"

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -119,31 +119,32 @@ object Command {
 
       val parseUserDefinedArgs =
         for {
-          commandOptionsAndArgs <- args match {
-                                     case head :: tail =>
-                                       ZIO
-                                         .succeed(tail)
-                                         .when(conf.normalizeCase(head) == conf.normalizeCase(self.name))
-                                         .some
-                                         .orElseFail {
-                                           ValidationError(
-                                             ValidationErrorType.CommandMismatch,
-                                             HelpDoc.p(s"Missing command name: ${self.name}")
-                                           )
-                                         }
-                                     case Nil =>
-                                       ZIO.fail {
-                                         ValidationError(
-                                           ValidationErrorType.CommandMismatch,
-                                           HelpDoc.p(s"Missing command name: ${self.name}")
-                                         )
-                                       }
-                                   }
-          tuple                     <- self.options.validate(unCluster(commandOptionsAndArgs), conf)
-          (commandArgs, optionsType) = tuple
-          tuple                     <- self.args.validate(commandArgs, conf)
-          (argsLeftover, argsType)   = tuple
-        } yield CommandDirective.userDefined(argsLeftover, (optionsType, argsType))
+          optionsAndArgs <- args match {
+                              case head :: tail =>
+                                ZIO
+                                  .succeed(tail)
+                                  .when(conf.normalizeCase(head) == conf.normalizeCase(self.name))
+                                  .some
+                                  .orElseFail {
+                                    ValidationError(
+                                      ValidationErrorType.CommandMismatch,
+                                      HelpDoc.p(s"Missing command name: ${self.name}")
+                                    )
+                                  }
+                              case Nil =>
+                                ZIO.fail {
+                                  ValidationError(
+                                    ValidationErrorType.CommandMismatch,
+                                    HelpDoc.p(s"Missing command name: ${self.name}")
+                                  )
+                                }
+                            }
+          tuple                                <- self.options.validate(unCluster(optionsAndArgs), conf)
+          (optionsLeftoverAndArgs, optionsType) = tuple
+          (optionsLeftover, args)               = optionsLeftoverAndArgs.partition(_.startsWith("-"))
+          tuple                                <- self.args.validate(args, conf)
+          (argsLeftover, argsType)              = tuple
+        } yield CommandDirective.userDefined(argsLeftover ++ optionsLeftover, (optionsType, argsType))
 
       parseBuiltInArgs orElse parseUserDefinedArgs
     }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -248,7 +248,7 @@ object Options {
           ) {
             ZIO.fail(
               ValidationError(
-                ValidationErrorType.MissingValue,
+                ValidationErrorType.InvalidValue,
                 p(error(s"""The flag "$head" is not recognized. Did you mean ${self.fullName}?"""))
               )
             )

--- a/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
@@ -11,7 +11,9 @@ sealed trait UsageSynopsis { self =>
     def render(g: UsageSynopsis): Span =
       g match {
         case Named(names, acceptedValues) =>
-          Span.text(names.mkString(", ")) + acceptedValues.fold(Span.empty)(c => Span.space + Span.text(c))
+          val mainSpan =
+            Span.text(names.mkString(", ")) + acceptedValues.fold(Span.empty)(c => Span.space + Span.text(c))
+          if (names.length > 1) Span.text("(") + mainSpan + Span.text(")") else mainSpan
 
         case Optional(value) =>
           Span.text("[") + render(value) + Span.text("]")

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -163,7 +163,20 @@ object OptionsSpec extends ZIOSpecDefault {
         equalTo(
           Left(
             ValidationError(
-              ValidationErrorType.MissingValue,
+              ValidationErrorType.InvalidValue,
+              p(error("""The flag "--firstme" is not recognized. Did you mean --firstname?"""))
+            )
+          )
+        )
+      )
+    },
+    test("returns a HelpDoc if an option with a default value is not an exact match, but is close") {
+      val r = f.withDefault("Jack").validate(List("--firstme"), CliConfig.default)
+      assertZIO(r.either)(
+        equalTo(
+          Left(
+            ValidationError(
+              ValidationErrorType.InvalidValue,
               p(error("""The flag "--firstme" is not recognized. Did you mean --firstname?"""))
             )
           )


### PR DESCRIPTION
On this PR:

- Upgrade GraalVM version to 22.3.0 in installer.sh, together with some adjustments so the script works correctly
- Fixed autocorrect logic in `Options` (`ValidationError.InvalidValue` is used now to suggest a correction instead of `ValidationError.MissingValue`. The problem with using `MissingValue` is that `Options` with default value handle this error and succeed with the default)
- Fixed logic of `Command.Single.parse`