### PR TITLE
Add support for OAuth2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17' ]
         scala: [ '2.12.17', '2.13.10', '3.2.2' ]
         platform: [ 'JVM', 'JS', 'Native' ]
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val zioCli = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"          % zioVersion,
+      "dev.zio" %% "zio-json"     % "0.5.0",
       "dev.zio" %% "zio-process"  % "0.7.1",
       "dev.zio" %% "zio-streams"  % zioVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,

--- a/examples/jvm/src/main/scala/zio/cli/examples/OAuth2.scala
+++ b/examples/jvm/src/main/scala/zio/cli/examples/OAuth2.scala
@@ -13,9 +13,8 @@ object OAuth2 extends ZIOCliDefault {
     Command(
       "oauth2",
       (
-        Options.oauth2(OAuth2Provider.Github("client_id"), Nil) ++ Options.boolean("v").alias("verbose")
-      ).map { case (t, v) => Cmd(t, v) },
-      Args.none
+        Options.oauth2(OAuth2Provider.Github("1234567890"), Nil) ++ Options.boolean("v").alias("verbose")
+      ).map { case (t, v) => Cmd(t, v) }
     )
 
   val cliApp = CliApp.make(

--- a/examples/jvm/src/main/scala/zio/cli/examples/OAuth2.scala
+++ b/examples/jvm/src/main/scala/zio/cli/examples/OAuth2.scala
@@ -1,0 +1,28 @@
+package zio.cli.examples
+
+import zio._
+import zio.cli._
+import zio.cli.HelpDoc.Span.text
+import zio.cli.oauth2.OAuth2Token
+import zio.cli.oauth2.OAuth2Provider
+
+object OAuth2 extends ZIOCliDefault {
+  case class Cmd(token: OAuth2Token, verbose: Boolean)
+
+  val oauth2: Command[Cmd] =
+    Command(
+      "oauth2",
+      (
+        Options.oauth2(OAuth2Provider.Github("client_id"), Nil) ++ Options.boolean("v").alias("verbose")
+      ).map { case (t, v) => Cmd(t, v) },
+      Args.none
+    )
+
+  val cliApp = CliApp.make(
+    name = "ZIO CLI OAuth2",
+    version = "0.0.1",
+    summary = text("Example of OAuth2 authorization using ZIO CLI"),
+    command = oauth2
+  )(_.token.accessToken.flatMap(at => Console.printLine(at).orDie))
+
+}

--- a/zio-cli/js/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -1,4 +1,4 @@
 package zio
 package cli
 
-trait OptionsPlatformSpecific { self: Options.type => }
+private[cli] trait OptionsPlatformSpecific { self: Options.type => }

--- a/zio-cli/js/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -1,0 +1,4 @@
+package zio
+package cli
+
+trait OptionsPlatformSpecific { self: Options.type => }

--- a/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -2,12 +2,21 @@ package zio
 package cli
 package oauth2
 
-object OAuth2PlatformSpecific {
+import com.github.ghik.silencer.silent
+
+@silent("never used")
+private[cli] object OAuth2PlatformSpecific {
   def validate(
     provider: OAuth2Provider,
     scope: List[String],
     auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
     args: List[String],
     conf: CliConfig
-  ): IO[ValidationError, (List[String], OAuth2Token)] = ???
+  ): IO[ValidationError, (List[String], OAuth2Token)] =
+    ZIO.dieMessage(
+      "OAuth2 support is not currently implemented for Scala.js. If you are interested in adding support, please open a pull request at https://github.com/zio/zio-cli."
+    )
+
+  def oauth2HelpSection(options: Options[Any]): HelpDoc =
+    HelpDoc.empty
 }

--- a/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -1,0 +1,13 @@
+package zio
+package cli
+package oauth2
+
+object OAuth2PlatformSpecific {
+  def validate(
+    provider: OAuth2Provider,
+    scope: List[String],
+    auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
+    args: List[String],
+    conf: CliConfig
+  ): IO[ValidationError, (List[String], OAuth2Token)] = ???
+}

--- a/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -13,13 +13,13 @@ private[cli] trait OptionsPlatformSpecific { self: Options.type =>
    */
   def oauth2(provider: OAuth2Provider, scope: List[String]): Options[OAuth2Token] = {
     val providerSegment = s"${provider.name.toLowerCase()}_${provider.clientIdentifier}"
+    val defaultFile =
+      JPaths.get(java.lang.System.getProperty("user.home"), s"oauth2_${providerSegment}_access_token.json")
 
     val accessTokenFile: Options[JPath] =
       Options
         .file("oauth2-file")
-        .withDefault(
-          JPaths.get(s"./oauth2_${providerSegment}_access_token.json")
-        ) ?? "File in which OAuth2 access token will be stored."
+        .withDefault(defaultFile) ?? "File in which OAuth2 access token will be stored."
 
     val auxiliaryOptions: Options[OAuth2AuxiliaryOptions] =
       accessTokenFile.map(OAuth2AuxiliaryOptions.apply)

--- a/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -5,18 +5,14 @@ import zio.cli.oauth2._
 
 import java.nio.file.{Path => JPath, Paths => JPaths}
 
-trait OptionsPlatformSpecific { self: Options.type =>
+private[cli] trait OptionsPlatformSpecific { self: Options.type =>
 
   /**
    * Adds into the application OAuth2 authorization with the specified `provider` for permissions
    * defined by `scope`. The resulting [[OAuth2Token]] will provide access token.
    */
   def oauth2(provider: OAuth2Provider, scope: List[String]): Options[OAuth2Token] = {
-    val providerSegment = provider match {
-      case OAuth2Provider.Github(clientId)    => s"github_$clientId"
-      case OAuth2Provider.Google(clientId, _) => s"google_$clientId"
-      case OAuth2Provider.Facebook(appId, _)  => s"facebook_$appId"
-    }
+    val providerSegment = s"${provider.name.toLowerCase()}_${provider.clientIdentifier}"
 
     val accessTokenFile: Options[JPath] =
       Options
@@ -26,7 +22,7 @@ trait OptionsPlatformSpecific { self: Options.type =>
         ) ?? "File in which OAuth2 access token will be stored."
 
     val auxiliaryOptions: Options[OAuth2AuxiliaryOptions] =
-      accessTokenFile.map(OAuth2AuxiliaryOptions)
+      accessTokenFile.map(OAuth2AuxiliaryOptions.apply)
 
     OAuth2Options(provider, scope, auxiliaryOptions)
   }

--- a/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -9,7 +9,7 @@ private[cli] trait OptionsPlatformSpecific { self: Options.type =>
 
   /**
    * Adds into the application OAuth2 authorization with the specified `provider` for permissions
-   * defined by `scope`. The resulting [[OAuth2Token]] will provide access token.
+   * defined by `scope`. The resulting [[zio.cli.oauth2.OAuth2Token]] will provide access token.
    */
   def oauth2(provider: OAuth2Provider, scope: List[String]): Options[OAuth2Token] = {
     val providerSegment = s"${provider.name.toLowerCase()}_${provider.clientIdentifier}"

--- a/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/OptionsPlatformSpecific.scala
@@ -1,0 +1,34 @@
+package zio
+package cli
+
+import zio.cli.oauth2._
+
+import java.nio.file.{Path => JPath, Paths => JPaths}
+
+trait OptionsPlatformSpecific { self: Options.type =>
+
+  /**
+   * Adds into the application OAuth2 authorization with the specified `provider` for permissions
+   * defined by `scope`. The resulting [[OAuth2Token]] will provide access token.
+   */
+  def oauth2(provider: OAuth2Provider, scope: List[String]): Options[OAuth2Token] = {
+    val providerSegment = provider match {
+      case OAuth2Provider.Github(clientId)    => s"github_$clientId"
+      case OAuth2Provider.Google(clientId, _) => s"google_$clientId"
+      case OAuth2Provider.Facebook(appId, _)  => s"facebook_$appId"
+    }
+
+    val accessTokenFile: Options[JPath] =
+      Options
+        .file("oauth2-file")
+        .withDefault(
+          JPaths.get(s"./oauth2_${providerSegment}_access_token.json")
+        ) ?? "File in which OAuth2 access token will be stored."
+
+    val auxiliaryOptions: Options[OAuth2AuxiliaryOptions] =
+      accessTokenFile.map(OAuth2AuxiliaryOptions)
+
+    OAuth2Options(provider, scope, auxiliaryOptions)
+  }
+
+}

--- a/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -21,14 +21,14 @@ private[cli] object OAuth2PlatformSpecific {
 
   def findProvider(opt: Options[Any]): Option[OAuth2Provider] =
     opt match {
-      case Both(left, right)                                    => findProvider(left).orElse(findProvider(right))
-      case Options.Map(value, f)                                => findProvider(value)
-      case KeyValueMap(argumentOption)                          => None
-      case Empty                                                => None
-      case Options.OrElse(left, right)                          => findProvider(left).orElse(findProvider(right))
-      case Options.Single(name, aliases, primType, description) => None
-      case OAuth2Options(provider, scope, auxiliaryOptions)     => Some(provider)
-      case WithDefault(options, default)                        => findProvider(options)
+      case Both(left, right)             => findProvider(left).orElse(findProvider(right))
+      case Options.Map(value, _)         => findProvider(value)
+      case KeyValueMap(_)                => None
+      case Empty                         => None
+      case Options.OrElse(left, right)   => findProvider(left).orElse(findProvider(right))
+      case Options.Single(_, _, _, _)    => None
+      case OAuth2Options(provider, _, _) => Some(provider)
+      case WithDefault(options, _)       => findProvider(options)
     }
 
   def oauth2HelpSection(options: Options[Any]): HelpDoc =

--- a/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -1,0 +1,20 @@
+package zio
+package cli
+package oauth2
+
+import zio.cli.HelpDoc.p
+
+object OAuth2PlatformSpecific {
+  def validate(
+    provider: OAuth2Provider,
+    scope: List[String],
+    auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
+    args: List[String],
+    conf: CliConfig
+  ): IO[ValidationError, (List[String], OAuth2Token)] =
+    auxiliaryOptions.validate(args, conf).flatMap { case (args, aux) =>
+      new OAuth2(provider, aux.file, scope).loadOrAuthorize
+        .mapError(ex => ValidationError(ValidationErrorType.InvalidValue, p(ex.getMessage)))
+        .map(token => (args, token))
+    }
+}

--- a/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -2,9 +2,10 @@ package zio
 package cli
 package oauth2
 
-import zio.cli.HelpDoc.p
+import zio.cli.HelpDoc.{h1, p}
+import zio.cli.Options._
 
-object OAuth2PlatformSpecific {
+private[cli] object OAuth2PlatformSpecific {
   def validate(
     provider: OAuth2Provider,
     scope: List[String],
@@ -17,4 +18,29 @@ object OAuth2PlatformSpecific {
         .mapError(ex => ValidationError(ValidationErrorType.InvalidValue, p(ex.getMessage)))
         .map(token => (args, token))
     }
+
+  def findProvider(opt: Options[Any]): Option[OAuth2Provider] =
+    opt match {
+      case Both(left, right)                                    => findProvider(left).orElse(findProvider(right))
+      case Options.Map(value, f)                                => findProvider(value)
+      case KeyValueMap(argumentOption)                          => None
+      case Empty                                                => None
+      case Options.OrElse(left, right)                          => findProvider(left).orElse(findProvider(right))
+      case Options.Single(name, aliases, primType, description) => None
+      case OAuth2Options(provider, scope, auxiliaryOptions)     => Some(provider)
+      case WithDefault(options, default)                        => findProvider(options)
+    }
+
+  def oauth2HelpSection(options: Options[Any]): HelpDoc =
+    findProvider(options).fold(HelpDoc.empty) { provider =>
+      h1("3rd party authorization") + HelpDoc.p(
+        s"""|This application requires 3rd party authorization (using OAuth2 protocol)
+            |provided by ${provider.name}. When the application is launched for the first time,
+            |instructions to perform the authorization will be displayed. Subsequent launches
+            |do not require any action unless the access has been revoked.
+            |
+            |Behavior of 3rd party authorization can be modified by options starting with '--oauth2-'.""".stripMargin
+      )
+    }
+
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -2,6 +2,7 @@ package zio.cli
 
 import zio.cli.HelpDoc.h1
 import zio.cli.ValidationErrorType.CommandMismatch
+import zio.cli.oauth2.OAuth2PlatformSpecific
 import zio.{IO, UIO, ZIO}
 
 /**
@@ -102,7 +103,9 @@ object Command {
         else h1("options") + opts
       }
 
-      helpHeader + argumentsSection + optionsSection
+      val oauth2Section = OAuth2PlatformSpecific.oauth2HelpSection(options)
+
+      helpHeader + argumentsSection + optionsSection + oauth2Section
     }
 
     lazy val names: Set[String] = Set(self.name)

--- a/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
@@ -112,6 +112,8 @@ object Completion {
       case Options.KeyValueMap(argumentOption) =>
         val optionGrammar = toRegularLanguage(argumentOption)
         Permutation(optionGrammar)
+      case o: Options.OAuth2Options =>
+        toRegularLanguage(o.auxiliaryOptions)
     }
 
   /**

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessToken.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessToken.scala
@@ -1,0 +1,19 @@
+package zio
+package cli
+package oauth2
+
+import java.time.OffsetDateTime
+
+import zio.json.{DeriveJsonCodec, JsonCodec}
+
+final case class AccessToken(
+  accessToken: String,
+  tokenType: TokenType,
+  expiresAt: Option[OffsetDateTime],
+  refreshToken: Option[String],
+  scope: List[String]
+)
+
+object AccessToken {
+  implicit val stateJsonCodec: JsonCodec[AccessToken] = DeriveJsonCodec.gen[AccessToken]
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
@@ -78,17 +78,17 @@ object AccessTokenResponse {
     sealed trait Kind extends Serializable with Product
 
     object Kind {
-      final case object InvalidRequest       extends Kind
-      final case object InvalidClient        extends Kind
-      final case object InvalidGrant         extends Kind
-      final case object UnauthorizedClient   extends Kind
-      final case object UnsupportedGrantType extends Kind
-      final case object InvalidScope         extends Kind
-      final case object AuthorizationPending extends Kind
-      final case object SlowDown             extends Kind
-      final case object AccessDenied         extends Kind
-      final case object ExpiredToken         extends Kind
-      final case class Other(code: String)   extends Kind
+      case object InvalidRequest           extends Kind
+      case object InvalidClient            extends Kind
+      case object InvalidGrant             extends Kind
+      case object UnauthorizedClient       extends Kind
+      case object UnsupportedGrantType     extends Kind
+      case object InvalidScope             extends Kind
+      case object AuthorizationPending     extends Kind
+      case object SlowDown                 extends Kind
+      case object AccessDenied             extends Kind
+      case object ExpiredToken             extends Kind
+      final case class Other(code: String) extends Kind
 
       implicit val kindJsonDecoder: JsonDecoder[Kind] =
         JsonDecoder.string.map {

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
@@ -1,0 +1,159 @@
+package zio
+package cli
+package oauth2
+
+import zio.json.{jsonMemberNames, DeriveJsonDecoder, JsonDecoder, SnakeCase}
+
+/**
+ * Response to access token request informing about progress of device
+ * authorization. The response can be either
+ * [[AccessTokenResponse.AccessToken]] in case of successful termination or
+ * [[AccessTokenRespnse.Error]] when any error occurrs.
+ *
+ * @see
+ *   https://datatracker.ietf.org/doc/html/rfc6749#section-5
+ */
+sealed trait AccessTokenResponse extends Serializable with Product
+
+object AccessTokenResponse {
+
+  /**
+   * Result of successful authorization process providing access token issued
+   * by the authorization server.
+   *
+   * @see
+   *   https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+   *
+   * @param accessToken
+   *   access token
+   * @param tokenType
+   *   type of token
+   * @param expiresIn
+   *   lifetime of access token
+   * @param refreshToken
+   *   refresh token for obtaining new access token
+   * @param scope
+   *   scope of access token
+   */
+  final case class AccessToken(
+    accessToken: String,
+    tokenType: TokenType,
+    expiresIn: Option[Duration],
+    refreshToken: Option[String],
+    scope: List[String]
+  ) extends AccessTokenResponse
+
+  /**
+   * Result of unsuccessful or still ongoing authorization process.
+   *
+   * @see
+   *   https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+   *
+   * @param error
+   *   kind of error
+   * @param errorDescription
+   *   human-readable textual expression of the error
+   * @param errorUri
+   *   URI to additional information about the error
+   * @param interval
+   *   minimum length of polling interval
+   */
+  final case class Error(
+    error: Error.Kind,
+    errorDescription: Option[String],
+    errorUri: Option[String],
+    interval: Option[Duration]
+  ) extends AccessTokenResponse
+
+  object Error {
+
+    /**
+     * Kind of error that can appear in access token response.
+     *
+     * @see
+     *   https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+     * @see
+     *   https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+     */
+    sealed trait Kind extends Serializable with Product
+
+    object Kind {
+      final case object InvalidRequest       extends Kind
+      final case object InvalidClient        extends Kind
+      final case object InvalidGrant         extends Kind
+      final case object UnauthorizedClient   extends Kind
+      final case object UnsupportedGrantType extends Kind
+      final case object InvalidScope         extends Kind
+      final case object AuthorizationPending extends Kind
+      final case object SlowDown             extends Kind
+      final case object AccessDenied         extends Kind
+      final case object ExpiredToken         extends Kind
+      final case class Other(code: String)   extends Kind
+
+      implicit val kindJsonDecoder: JsonDecoder[Kind] =
+        JsonDecoder.string.map {
+          case "invalid_request"        => InvalidRequest
+          case "invalid_client"         => InvalidClient
+          case "invalid_grant"          => InvalidGrant
+          case "unauthorized_client"    => UnauthorizedClient
+          case "unsupported_grant_type" => UnsupportedGrantType
+          case "invalid_scope"          => InvalidScope
+          case "authorization_pending"  => AuthorizationPending
+          case "slow_down"              => SlowDown
+          case "access_denied"          => AccessDenied
+          case "expired_token"          => ExpiredToken
+          case code                     => Other(code)
+        }
+    }
+  }
+
+  @jsonMemberNames(SnakeCase)
+  private[this] final case class AccessTokenRaw(
+    accessToken: String,
+    tokenType: TokenType,
+    expiresIn: Option[Long],
+    refreshToken: Option[String],
+    scope: Option[String]
+  )
+
+  @jsonMemberNames(SnakeCase)
+  private final case class ErrorRaw(
+    error: Error.Kind,
+    errorDescription: Option[String],
+    errorUri: Option[String],
+    interval: Option[Long]
+  )
+
+  private[this] val errorJsonDecoder: JsonDecoder[AccessTokenResponse] =
+    DeriveJsonDecoder
+      .gen[ErrorRaw]
+      .map(raw =>
+        Error(
+          raw.error,
+          raw.errorDescription,
+          raw.errorUri,
+          raw.interval.map(Duration.fromSeconds)
+        )
+      )
+      .widen
+
+  private[this] val accessTokenJsonDecoder: JsonDecoder[AccessTokenResponse] =
+    DeriveJsonDecoder
+      .gen[AccessTokenRaw]
+      .map(raw =>
+        AccessToken(
+          raw.accessToken,
+          raw.tokenType,
+          raw.expiresIn.map(Duration.fromSeconds),
+          raw.refreshToken,
+          raw.scope.map(_.split(",| ").toList).getOrElse(List.empty)
+        )
+      )
+      .widen
+
+  /**
+   * JSON decoder for [[AccessTokenResponse]].
+   */
+  val accessTokenResponseJsonDecoder: JsonDecoder[AccessTokenResponse] =
+    errorJsonDecoder <> accessTokenJsonDecoder
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/AccessTokenResponse.scala
@@ -8,7 +8,7 @@ import zio.json.{jsonMemberNames, DeriveJsonDecoder, JsonDecoder, SnakeCase}
  * Response to access token request informing about progress of device
  * authorization. The response can be either
  * [[AccessTokenResponse.AccessToken]] in case of successful termination or
- * [[AccessTokenRespnse.Error]] when any error occurrs.
+ * [[AccessTokenResponse.Error]] when any error occurrs.
  *
  * @see
  *   https://datatracker.ietf.org/doc/html/rfc6749#section-5

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/AuthorizationResponse.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/AuthorizationResponse.scala
@@ -1,0 +1,64 @@
+package zio
+package cli
+package oauth2
+
+import zio.json.{jsonMemberNames, DeriveJsonDecoder, JsonDecoder, SnakeCase}
+
+/**
+ * Response to device authorization request providing end-user verification
+ * code.
+ *
+ * @see
+ *   https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
+ *
+ * @param deviceCode
+ *   device verification code
+ * @param userCode
+ *   end-user verification code
+ * @param verificationUri
+ *   end-user verification URI
+ * @param verificationUriComplete
+ *   end-user verification URI with `userCode`
+ * @param expiresIn
+ *   lifetime od `deviceCode` and `userCode`
+ * @param interval
+ *   polling interval
+ */
+final case class AuthorizationResponse(
+  deviceCode: String,
+  userCode: String,
+  verificationUri: String,
+  verificationUriComplete: Option[String],
+  expiresIn: Duration,
+  interval: Duration
+)
+
+object AuthorizationResponse {
+
+  @jsonMemberNames(SnakeCase)
+  private[this] final case class AuthorizationResponseRaw(
+    deviceCode: String,
+    userCode: String,
+    verificationUri: String,
+    verificationUriComplete: Option[String],
+    expiresIn: Long,
+    interval: Option[Long]
+  )
+
+  /**
+   * JSON decoder for [[AuthorizationResponse]].
+   */
+  val authorizationResponseJsonDecoder: JsonDecoder[AuthorizationResponse] =
+    DeriveJsonDecoder
+      .gen[AuthorizationResponseRaw]
+      .map(raw =>
+        AuthorizationResponse(
+          raw.deviceCode,
+          raw.userCode,
+          raw.verificationUri,
+          raw.verificationUriComplete,
+          Duration.fromSeconds(raw.expiresIn),
+          raw.interval.map(Duration.fromSeconds).getOrElse(5.seconds)
+        )
+      )
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
@@ -1,0 +1,259 @@
+package zio
+package cli
+package oauth2
+
+import java.net.http.{HttpClient, HttpResponse}
+import java.nio.file.Path
+
+import zio.json._
+
+class OAuth2(provider: OAuth2Provider, file: Path, scope: List[String]) {
+  val client = HttpClient.newBuilder().build()
+
+  /**
+   * Returns [[OAuth2Token]] either loaded from file (if available)
+   * or by authorizing on `provider`s server.
+   */
+  def loadOrAuthorize: Task[OAuth2Token] =
+    Clock.currentDateTime.flatMap { time =>
+      loadFromFile.flatMap {
+        // Not expired
+        case Some(accessToken) if accessToken.expiresAt.forall(_.isAfter(time)) => ZIO.succeed(accessToken)
+        // Expired
+        case Some(accessToken) => refreshAccessToken(accessToken)
+        // Not existing
+        case _ => authorize
+      }.flatMap(makeOAuth2Token)
+    }
+
+  /**
+   * Performs OAuth2 authorization, returns access token as received from
+   * the authorization server.
+   */
+  def authorize: Task[AccessToken] =
+    requestAuthorization.tap(informUser).flatMap(waitForAccessToken)
+
+  /**
+   * Attempts to load recent access token from file; returns `None` if
+   * the file could not be found, could not be decrypted or could not be decoded.
+   */
+  def loadFromFile: Task[Option[AccessToken]] =
+    ZIO.readFile(file).option.map(_.flatMap(_.fromJson[AccessToken].toOption))
+
+  /**
+   * Creates [[OAuth2Token]] object from original access token (either
+   * loaded from file or freshly obtained from authorization server).
+   *
+   * @param initialToken original access token
+   */
+  def makeOAuth2Token(initialToken: AccessToken): UIO[OAuth2Token] =
+    Ref.Synchronized
+      .make(initialToken)
+      .map(ref =>
+        new OAuth2Token {
+          val refreshTokenNow = ref.updateZIO(refreshAccessToken)
+          val accessToken =
+            ref.updateAndGetZIO { acc =>
+              Clock.currentDateTime.flatMap { time =>
+                acc.expiresAt.map(_.isBefore(time)) match {
+                  // Expired
+                  case Some(true) => refreshAccessToken(acc)
+                  // No expiration or not yet expired
+                  case _ => ZIO.succeed(acc)
+                }
+              }
+            }
+        }
+      )
+
+  /**
+   * Refreshes access token, either by re-authorizing or by
+   * using refresh token, if available.
+   *
+   * @param accessToken original access token
+   */
+  def refreshAccessToken(accessToken: AccessToken): Task[AccessToken] =
+    accessToken.refreshToken.fold(authorize)(requestRefreshToken)
+
+  /**
+   * Sends to an authorization server request for authorization.
+   */
+  def requestAuthorization: Task[AuthorizationResponse] =
+    ZIO
+      .fromCompletableFuture(
+        client.sendAsync(
+          provider.authorizationRequest(scope),
+          HttpResponse.BodyHandlers.ofString()
+        )
+      )
+      .flatMap(response =>
+        if (response.statusCode() == 200) {
+          ZIO
+            .fromEither(provider.decodeAuthorizationResponse(response.body()))
+            .mapError(e => new Exception(s"Response of authorization request could not be decoded: $e"))
+        } else {
+          ZIO.fail(
+            new Exception(s"Authorization server returned error after authorization request: ${response.body()}")
+          )
+        }
+      )
+
+  def waitForAccessToken(response: AuthorizationResponse): Task[AccessToken] =
+    ZIO
+      .fromCompletableFuture(
+        client.sendAsync(
+          provider.accessTokenRequest(response),
+          HttpResponse.BodyHandlers.ofString()
+        )
+      )
+      .flatMap(response =>
+        ZIO.fromEither(
+          provider
+            .decodeAccessTokenResponse(response.body())
+            .left
+            .map(e => new Exception(s"Response of access token request could not be decoded: $e"))
+        )
+      )
+      .repeat(pollingSchedule(response.interval, response.expiresIn))
+      .flatMap(res => processResponse(res, None))
+
+  /**
+   * Creates ZIO Schedule for regular polling of authentication server
+   * until the response indicates success, failure or time has expired.
+   *
+   * Initial interval is `interval`. This interval can increase by
+   * `slow_down` requests from server. The schedule will terminate when
+   * `expiresIn` has elapsed.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+   * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+   *
+   * @param interval initial polling interval
+   * @param expiresIn maximum period
+   * @return the last response received before terminating
+   */
+  def pollingSchedule(
+    interval: Duration,
+    expiresIn: Duration
+  ): Schedule[Any, AccessTokenResponse, AccessTokenResponse] = {
+    import AccessTokenResponse._
+    import AccessTokenResponse.Error.Kind._
+
+    // Generate delays for each poll attempt. It starts with `interval`.
+    // Every `slow_down` will increase delay of this round and of
+    // all future rounds by given interval.
+    val delays: Schedule[Any, AccessTokenResponse, Duration] =
+      Schedule
+        .identity[AccessTokenResponse]
+        .map {
+          case e: Error if e.error == SlowDown =>
+            // Delay is added only when `slow_down` was requested.
+            e.interval.orElse(Some(5.seconds))
+          case _ => None
+        }
+        // Add additional delay to this round if required.
+        .addDelay(_.getOrElse(Duration.Zero))
+        // Increase delays to following rounds if required.
+        .fold(interval) {
+          case (duration, Some(interval)) => duration + interval
+          case (duration, _)              => duration
+        }
+
+    Schedule.delayed(delays) *>
+      Schedule
+        .recurWhile[AccessTokenResponse](_ match {
+          case e: Error =>
+            e.error == AuthorizationPending || e.error == SlowDown
+          case _ => false
+        })
+        .upTo(expiresIn)
+  }
+
+  /**
+   * Sends to an authorization server request to refresh access token
+   * using a refresh token.
+   */
+  def requestRefreshToken(refreshToken: String): Task[AccessToken] =
+    ZIO
+      .fromEither(
+        provider
+          .refreshTokenRequest(refreshToken)
+          .toRight(new Exception("Authorization server does not support refresh tokens."))
+      )
+      .flatMap(request => ZIO.fromCompletableFuture(client.sendAsync(request, HttpResponse.BodyHandlers.ofString())))
+      .flatMap(response =>
+        if (response.statusCode() == 200) {
+          ZIO
+            .fromEither(
+              provider
+                .decodeAccessTokenResponse(response.body())
+                .left
+                .map(e => new Exception(s"Response of refresh token request could not be decoded: $e"))
+            )
+        } else {
+          ZIO.fail(
+            new Exception(s"Authorization server returned error after refresh token request: ${response.body()}")
+          )
+        }
+      )
+      .flatMap(res => processResponse(res, Some(refreshToken)))
+
+  /**
+   * Converts standard access token response into [[AccessToken]] and saves it to file.
+   * If response contained an error, it will be
+   */
+  def processResponse(response: AccessTokenResponse, refreshToken: Option[String]): Task[AccessToken] =
+    response match {
+      case e: AccessTokenResponse.Error =>
+        val description = e.errorDescription.map(d => s" and with message: '$d'").getOrElse("")
+        val uri         = e.errorUri.map(uri => s" For more information visit: $uri").getOrElse("")
+
+        ZIO.fail(new Exception(s"Authorization server returned error of type ${e.error}$description.$uri"))
+      case t: AccessTokenResponse.AccessToken =>
+        Clock.currentDateTime
+          .map(time =>
+            AccessToken(
+              t.accessToken,
+              t.tokenType,
+              t.expiresIn.map(exp => time.plus(exp)),
+              refreshToken.orElse(t.refreshToken),
+              t.scope
+            )
+          )
+          .tap(token => ZIO.writeFile(file, token.toJson))
+    }
+
+  /**
+   * Prints an information box with instructions how to confirm
+   * authorization request.
+   */
+  def informUser(response: AuthorizationResponse): UIO[Unit] =
+    Clock.localDateTime.map { time =>
+      val boxUrlLength  = response.verificationUri.length() + 2
+      val boxCodeLength = response.userCode.length() + 2
+      val expiresIn     = response.expiresIn.toMinutes()
+      val expiresAt     = time.plus(response.expiresIn).withNano(0).toLocalTime()
+
+      s"""| >>
+          | >>  Application requests to perform OAuth2
+          | >>  authorization.
+          | >>
+          | >>  Visit following URL in a browser:
+          | >>
+          | >>   ┏${"━" * boxUrlLength}┓
+          | >>   ┃ ${response.verificationUri} ┃
+          | >>   ┗${"━" * boxUrlLength}┛
+          | >>
+          | >>  And enter following code:
+          | >>
+          | >>   ┏${"━" * boxCodeLength}┓
+          | >>   ┃ ${response.userCode} ┃
+          | >>   ┗${"━" * boxCodeLength}┛
+          | >>
+          | >>  Code will expire in $expiresIn minutes at $expiresAt.
+          | >>
+""".stripMargin
+    }
+      .flatMap(text => Console.printLine(s"${text}\nWaiting...").orDie)
+
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 import zio.json._
 
-class OAuth2(provider: OAuth2Provider, file: Path, scope: List[String]) {
+private[cli] class OAuth2(provider: OAuth2Provider, file: Path, scope: List[String]) {
   val client = HttpClient.newBuilder().build()
 
   /**

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2AuxiliaryOptions.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2AuxiliaryOptions.scala
@@ -1,0 +1,12 @@
+package zio
+package cli
+package oauth2
+
+import java.nio.file.Path
+
+/**
+ * Set of options that can be provided to fine-tune OAuth2 authorization.
+ *
+ * @param file path to file where access token will be stored
+ */
+final case class OAuth2AuxiliaryOptions(file: Path)

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
@@ -219,7 +219,7 @@ object OAuth2Provider {
         )
 
     override def decodeAccessTokenResponse(body: String): Either[String, AccessTokenResponse] = {
-      val decodeSuccess =
+      val decodeSuccess: Either[String, AccessTokenResponse] =
         Facebook.fbAccessTokenResponse
           .decodeJson(body)
           .map(fb =>
@@ -227,7 +227,7 @@ object OAuth2Provider {
               .AccessToken(fb.accessToken, TokenType.Bearer, Some(Duration.fromSeconds(fb.expiresIn)), None, List.empty)
           )
 
-      val decodeError =
+      val decodeError: Either[String, AccessTokenResponse] =
         Facebook.fbAccessTokenError
           .decodeJson(body)
           .map { fb =>
@@ -243,7 +243,11 @@ object OAuth2Provider {
               .Error(kind, Some(fb.error.errorUserMsg), None, None)
           }
 
-      decodeError.orElse(decodeSuccess)
+      // 2.12-friendly decodeError.orElse(decodeSuccess)
+      decodeError match {
+        case r @ Right(_) => r
+        case _            => decodeSuccess
+      }
     }
   }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
@@ -1,0 +1,266 @@
+package zio
+package cli
+package oauth2
+
+import java.net.URI
+import java.net.http.HttpRequest
+
+import zio.json._
+
+/**
+ * Provider of OAuth2 authorization.
+ */
+sealed trait OAuth2Provider extends Serializable with Product {
+
+  /**
+   * Generates HTTP request for authorization request.
+   */
+  def authorizationRequest(scope: List[String]): HttpRequest
+
+  /**
+   * Generates HTTP request for access token request.
+   */
+  def accessTokenRequest(authorization: AuthorizationResponse): HttpRequest
+
+  /**
+   * Generates HTTP request for refresh token request. Returns `None` if this
+   * operation is not supported by the provider.
+   */
+  def refreshTokenRequest(refreshToken: String): Option[HttpRequest]
+
+  /**
+   * Converts textual response of authorization request into [[AuthorizationResponse]].
+   * Defaults to decoding from standard JSON format, can be overridden if OAuth2 server does
+   * not adhere to this standard.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
+   *
+   * @param body response body
+   * @return decoded authorization response
+   */
+  def decodeAuthorizationResponse(body: String): Either[String, AuthorizationResponse] =
+    AuthorizationResponse.authorizationResponseJsonDecoder.decodeJson(body)
+
+  /**
+   * Converts textual response of access token request into [[AccessTokenResponse]].
+   * Defaults to decoding from standard JSON format, can be overriden if OAuth2 server
+   * does not adhere to this standard.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+   * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+   *
+   * @param body response body
+   * @return decoded access token response
+   */
+  def decodeAccessTokenResponse(body: String): Either[String, AccessTokenResponse] =
+    AccessTokenResponse.accessTokenResponseJsonDecoder.decodeJson(body)
+}
+
+object OAuth2Provider {
+
+  final case class Github(clientId: String) extends OAuth2Provider {
+
+    override def authorizationRequest(scope: List[String]): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"https://github.com/login/device/code?client_id=$clientId&scope=${scope.mkString(",")}"))
+        .header("Accept", "application/json")
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build()
+
+    override def accessTokenRequest(authorization: AuthorizationResponse): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(
+          URI.create(
+            s"https://github.com/login/oauth/access_token?client_id=$clientId&device_code=${authorization.deviceCode}&grant_type=urn:ietf:params:oauth:grant-type:device_code"
+          )
+        )
+        .header("Accept", "application/json")
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build()
+
+    override def refreshTokenRequest(refreshToken: String): Option[HttpRequest] = None
+  }
+
+  final case class Google(clientId: String, clientSecret: String) extends OAuth2Provider {
+
+    override def authorizationRequest(scope: List[String]): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(
+          URI.create("https://oauth2.googleapis.com/device/code")
+        )
+        .headers("Content-Type", "application/x-www-form-urlencoded")
+        .POST(HttpRequest.BodyPublishers.ofString(s"client_id=$clientId&scope=${scope.mkString("%20")}"))
+        .build()
+
+    override def accessTokenRequest(authorization: AuthorizationResponse): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(
+          URI.create("https://oauth2.googleapis.com/token")
+        )
+        .headers("Content-Type", "application/x-www-form-urlencoded")
+        .POST(
+          HttpRequest.BodyPublishers.ofString(
+            s"client_id=$clientId&client_secret=$clientSecret&device_code=${authorization.deviceCode}&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"
+          )
+        )
+        .build()
+
+    override def refreshTokenRequest(refreshToken: String): Option[HttpRequest] =
+      Some(
+        HttpRequest
+          .newBuilder()
+          .uri(
+            URI.create(s"https://oauth2.googleapis.com/token")
+          )
+          .headers("Content-Type", "application/x-www-form-urlencoded")
+          .POST(
+            HttpRequest.BodyPublishers.ofString(
+              s"client_id=$clientId&client_secret=$clientSecret&refresh_token=$refreshToken&grant_type=refresh_token"
+            )
+          )
+          .build()
+      )
+
+    override def decodeAuthorizationResponse(body: String): Either[String, AuthorizationResponse] =
+      Google.gAuthorizationResponseDecoder
+        .decodeJson(body)
+        .map(g =>
+          AuthorizationResponse(
+            g.deviceCode,
+            g.userCode,
+            g.verificationUrl,
+            None,
+            Duration.fromSeconds(g.expiresIn),
+            Duration.fromSeconds(g.interval)
+          )
+        )
+  }
+
+  object Google {
+    @jsonMemberNames(SnakeCase)
+    final case class GAuthorizationResponse(
+      deviceCode: String,
+      userCode: String,
+      verificationUrl: String,
+      expiresIn: Long,
+      interval: Long
+    )
+
+    val gAuthorizationResponseDecoder: JsonDecoder[GAuthorizationResponse] =
+      DeriveJsonDecoder.gen[GAuthorizationResponse]
+  }
+
+  final case class Facebook(appId: String, clientToken: String) extends OAuth2Provider {
+    val fbAccessToken = s"$appId%7C$clientToken"
+
+    override def authorizationRequest(scope: List[String]): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(
+          URI.create(
+            s"https://graph.facebook.com/v2.6/device/login?access_token=$fbAccessToken&scope=${scope.mkString(",")}"
+          )
+        )
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build()
+
+    override def accessTokenRequest(authorization: AuthorizationResponse): HttpRequest =
+      HttpRequest
+        .newBuilder()
+        .uri(
+          URI.create(
+            s"https://graph.facebook.com/v2.6/device/login_status?access_token=$fbAccessToken&code=${authorization.deviceCode}"
+          )
+        )
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build()
+
+    override def refreshTokenRequest(refreshToken: String): Option[HttpRequest] = None
+
+    override def decodeAuthorizationResponse(body: String): Either[String, AuthorizationResponse] =
+      Facebook.fbAuthorizationResponseDecoder
+        .decodeJson(body)
+        .map(fb =>
+          AuthorizationResponse(
+            fb.code,
+            fb.userCode,
+            fb.verificationUri,
+            None,
+            Duration.fromSeconds(fb.expiresIn),
+            Duration.fromSeconds(fb.interval)
+          )
+        )
+
+    override def decodeAccessTokenResponse(body: String): Either[String, AccessTokenResponse] = {
+      val decodeSuccess =
+        Facebook.fbAccessTokenResponse
+          .decodeJson(body)
+          .map(fb =>
+            AccessTokenResponse
+              .AccessToken(fb.accessToken, TokenType.Bearer, Some(Duration.fromSeconds(fb.expiresIn)), None, List.empty)
+          )
+
+      val decodeError =
+        Facebook.fbAccessTokenError
+          .decodeJson(body)
+          .map { fb =>
+            val kind = fb.error.errorSubcode match {
+              case 1349174 => AccessTokenResponse.Error.Kind.AuthorizationPending
+              case 1349172 => AccessTokenResponse.Error.Kind.SlowDown
+              case 1349152 => AccessTokenResponse.Error.Kind.ExpiredToken
+              case 1349175 => AccessTokenResponse.Error.Kind.InvalidRequest
+              case _       => AccessTokenResponse.Error.Kind.Other(fb.error.message)
+            }
+
+            AccessTokenResponse
+              .Error(kind, Some(fb.error.errorUserMsg), None, None)
+          }
+
+      decodeError.orElse(decodeSuccess)
+    }
+  }
+
+  object Facebook {
+    @jsonMemberNames(SnakeCase)
+    final case class FBAuthorizationResponse(
+      code: String,
+      userCode: String,
+      verificationUri: String,
+      expiresIn: Long,
+      interval: Long
+    )
+
+    @jsonMemberNames(SnakeCase)
+    final case class FBAccessTokenResponse(
+      accessToken: String,
+      expiresIn: Long
+    )
+
+    final case class FBAccessTokenError(error: FBAccessTokenErrorContent)
+
+    @jsonMemberNames(SnakeCase)
+    final case class FBAccessTokenErrorContent(
+      message: String,
+      errorSubcode: Long,
+      errorUserMsg: String
+    )
+
+    val fbAuthorizationResponseDecoder: JsonDecoder[FBAuthorizationResponse] =
+      DeriveJsonDecoder.gen[FBAuthorizationResponse]
+
+    val fbAccessTokenResponse: JsonDecoder[FBAccessTokenResponse] =
+      DeriveJsonDecoder.gen[FBAccessTokenResponse]
+
+    implicit val fbAccessTokenErrorContent: JsonDecoder[FBAccessTokenErrorContent] =
+      DeriveJsonDecoder.gen[FBAccessTokenErrorContent]
+
+    val fbAccessTokenError: JsonDecoder[FBAccessTokenError] =
+      DeriveJsonDecoder.gen[FBAccessTokenError]
+
+  }
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
@@ -10,7 +10,19 @@ import zio.json._
 /**
  * Provider of OAuth2 authorization.
  */
-sealed trait OAuth2Provider extends Serializable with Product {
+trait OAuth2Provider {
+
+  /**
+   * Name of the provider.
+   */
+  def name: String
+
+  /**
+   * Public client identifier as provided after registration on authorization
+   * server. It is used for generating default file name, which holds
+   * access token.
+   */
+  def clientIdentifier: String
 
   /**
    * Generates HTTP request for authorization request.
@@ -60,6 +72,9 @@ sealed trait OAuth2Provider extends Serializable with Product {
 object OAuth2Provider {
 
   final case class Github(clientId: String) extends OAuth2Provider {
+    override val name = "Github"
+
+    override val clientIdentifier = clientId
 
     override def authorizationRequest(scope: List[String]): HttpRequest =
       HttpRequest
@@ -85,6 +100,9 @@ object OAuth2Provider {
   }
 
   final case class Google(clientId: String, clientSecret: String) extends OAuth2Provider {
+    override val name = "Google"
+
+    override val clientIdentifier = clientId
 
     override def authorizationRequest(scope: List[String]): HttpRequest =
       HttpRequest
@@ -156,6 +174,10 @@ object OAuth2Provider {
   }
 
   final case class Facebook(appId: String, clientToken: String) extends OAuth2Provider {
+    override val name = "Facebook"
+
+    override val clientIdentifier = appId
+
     val fbAccessToken = s"$appId%7C$clientToken"
 
     override def authorizationRequest(scope: List[String]): HttpRequest =

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Token.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Token.scala
@@ -1,0 +1,28 @@
+package zio
+package cli
+package oauth2
+
+/**
+ * Access point to OAuth2 access token. An instance can be obtained
+ * by using [[Options.oauth2]].
+ *
+ * Normal lifecycle of the access token is handled automatically when calling
+ * [[accessToken]], i. e. when token has normally expired, it will be
+ * refreshed. However, if the token is invalidated in any other way,
+ * it will not be detected and therefore the token will not be refreshed
+ * automatically. In such case, [[refreshTokenNow]] can be called.
+ */
+trait OAuth2Token {
+
+  /**
+   * Returns current access token. This may call authorization server
+   * for refreshing the token, if it has already expired.
+   */
+  def accessToken: Task[AccessToken]
+
+  /**
+   * Refresh access token, either by using refresh token (if available)
+   * or by reauthorziing.
+   */
+  def refreshTokenNow: Task[Unit]
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Token.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Token.scala
@@ -3,8 +3,7 @@ package cli
 package oauth2
 
 /**
- * Access point to OAuth2 access token. An instance can be obtained
- * by using [[Options.oauth2]].
+ * Access point to OAuth2 access token.
  *
  * Normal lifecycle of the access token is handled automatically when calling
  * [[accessToken]], i. e. when token has normally expired, it will be

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/TokenType.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/TokenType.scala
@@ -1,0 +1,32 @@
+package zio
+package cli
+package oauth2
+
+import zio.json.JsonCodec
+
+/**
+ * Access token type informing user about how to use access token.
+ *
+ *  @see https://datatracker.ietf.org/doc/html/rfc6749#section-7.1
+ */
+sealed trait TokenType extends Product with Serializable
+object TokenType {
+  final case object Bearer                  extends TokenType
+  final case object Mac                     extends TokenType
+  final case class Other(tokenType: String) extends TokenType
+
+  implicit val tokenTypeJsonDecoder: JsonCodec[TokenType] =
+    JsonCodec.string.transform(
+      {
+        case "bearer" => Bearer
+        case "mac"    => Mac
+        case other    => Other(other)
+
+      },
+      {
+        case Bearer       => "bearer"
+        case Mac          => "mac"
+        case Other(other) => other
+      }
+    )
+}


### PR DESCRIPTION
Draft of OAuth2 support, which should utlimately resolve #187 and hopefully will allow me to /claim #187.

Current status:

- [X] OAuth2 process (messages, polling, errors etc.)
- [X] Github support
- [X] Facebook support
- [X] Google support
- [X] Refreshing tokens
- [X] Storing of tokens to files
- [x] Pretty output
- [x] Figure out what to do with JS (HTTP client)
- [x] Finish🇫🇮 and polish🇵🇱 code (a few more types, remove `???`, comments)
- [x] Figure out JSON decoders (is there no way to create decoder of a product from product of decoders?)
- [x] Documentation
- ~Tests~

Issues:

- Works only on JVM with Java 11+
- Requires additional dependency (ZIO JSON)

Showcase:

![image](https://github.com/zio/zio-cli/assets/1381856/4550e5f4-4714-429c-bcfe-1a0154de7140)
