### PR TITLE
Make the project `zio.cli.sbt/sbt-zio-cli` publishable by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,11 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
       - name: Run tests
-        if: ${{ !startsWith(matrix.scala, '3.2.') }}
-        run: sbt ++${{ matrix.scala }}! test
+        if: ${{ !startsWith(matrix.scala, '3.') }}
+        run: sbt "++${{ matrix.scala }} test"
       - name: Run dotty tests
-        if: ${{ startsWith(matrix.scala, '3.2.') && matrix.platform == 'JVM' }}
-        run: sbt ++${{ matrix.scala }}! test
+        if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
+        run: sbt "++${{ matrix.scala }} test"
 
   publish:
     runs-on: ubuntu-20.04

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,8 @@ lazy val root = project
   .in(file("."))
   .settings(
     publish / skip := true,
-    unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
+    unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
+    crossScalaVersions := Nil,
   )
   .aggregate(
     zioCliJVM,
@@ -109,7 +110,8 @@ lazy val sbtZioCli = project
   .settings(
     name         := "sbt-zio-cli",
     organization := "zio.cli.sbt",
-    scalaVersion := "2.12.17",
+    scalaVersion := Scala212,
+    crossScalaVersions := Seq(Scala212),
     version      := "0.0.0-SNAPSHOT",
     addSbtPlugin("org.scalameta" %% "sbt-native-image" % "0.3.2")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val zioVersion = "2.0.15"
 lazy val root = project
   .in(file("."))
   .settings(
-    skip / publish := true,
+    publish / skip := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
   )
   .aggregate(
@@ -41,7 +41,8 @@ lazy val root = project
     zioCliJS,
     examplesJVM,
     examplesJS,
-    docs
+    docs,
+    sbtZioCli,
   )
 
 lazy val zioCli = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val root = project
   .settings(
     publish / skip := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),
-    crossScalaVersions := Nil,
+    crossScalaVersions := Nil
   )
   .aggregate(
     zioCliJVM,
@@ -43,7 +43,7 @@ lazy val root = project
     examplesJVM,
     examplesJS,
     docs,
-    sbtZioCli,
+    sbtZioCli
   )
 
 lazy val zioCli = crossProject(JSPlatform, JVMPlatform)
@@ -108,11 +108,11 @@ lazy val docs = project
 lazy val sbtZioCli = project
   .in(file("sbt-zio-cli"))
   .settings(
-    name         := "sbt-zio-cli",
-    organization := "zio.cli.sbt",
-    scalaVersion := Scala212,
+    name               := "sbt-zio-cli",
+    organization       := "zio.cli.sbt",
+    scalaVersion       := Scala212,
     crossScalaVersions := Seq(Scala212),
-    version      := "0.0.0-SNAPSHOT",
+    version            := "0.0.0-SNAPSHOT",
     addSbtPlugin("org.scalameta" %% "sbt-native-image" % "0.3.2")
   )
   .enablePlugins(SbtPlugin)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -11,9 +11,9 @@ import scalafix.sbt.ScalafixPlugin.autoImport._
 
 object BuildHelper {
 
-  private val Scala212 = "2.12.17"
-  private val Scala213 = "2.13.10"
-  val Scala3           = "3.3.0"
+  val Scala212 = "2.12.17"
+  val Scala213 = "2.13.10"
+  val Scala3   = "3.3.0"
 
   val SilencerVersion = "1.17.13"
 

--- a/sbt-zio-cli/src/main/scala/zio/cli/sbt/ZIOCLIPlugin.scala
+++ b/sbt-zio-cli/src/main/scala/zio/cli/sbt/ZIOCLIPlugin.scala
@@ -7,19 +7,17 @@ object ZIOCLIPlugin extends AutoPlugin with ZIOCLIPluginKeys {
   override def requires = NativeImagePlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    zioCliNativeImageReady := {
-      () => {
-        println("ZIO CLI App Native Image Ready!")
-      }
+    zioCliNativeImageReady := { () =>
+      println("ZIO CLI App Native Image Ready!")
     },
     zioCliNativeImageOptions := List(
       "--allow-incomplete-classpath",
       "--report-unsupported-elements-at-runtime",
       "--initialize-at-build-time",
-      "--no-fallback",
+      "--no-fallback"
     ),
-    zioCliMainClass := None,
-    requires.autoImport.nativeImageReady := zioCliNativeImageReady.value,
+    zioCliMainClass                        := None,
+    requires.autoImport.nativeImageReady   := zioCliNativeImageReady.value,
     requires.autoImport.nativeImageOptions := zioCliNativeImageOptions.value,
     zioCliBuildNative := {
       Compile / mainClass := {
@@ -36,7 +34,6 @@ object ZIOCLIPlugin extends AutoPlugin with ZIOCLIPluginKeys {
     zioCliGenerateZshCompletion := {
       println("TODO: Not Implemented!")
     }
-
   )
 
 }

--- a/sbt-zio-cli/src/main/scala/zio/cli/sbt/ZIOCLIPluginKeys.scala
+++ b/sbt-zio-cli/src/main/scala/zio/cli/sbt/ZIOCLIPluginKeys.scala
@@ -5,12 +5,15 @@ import sbt._
 trait ZIOCLIPluginKeys {
 
   lazy val zioCliMainClass = settingKey[Option[String]]("The mainClass of the CLI App in the Compile scope")
-  lazy val zioCliNativeImageOptions = settingKey[Seq[String]]("A collection of arguments to pass the native-image builder to customize native image generation")
-  lazy val zioCliNativeImageReady = settingKey[() => Unit]("A side-effecting callback that is called the native image is ready.")
+  lazy val zioCliNativeImageOptions = settingKey[Seq[String]](
+    "A collection of arguments to pass the native-image builder to customize native image generation"
+  )
+  lazy val zioCliNativeImageReady =
+    settingKey[() => Unit]("A side-effecting callback that is called the native image is ready.")
 
-  lazy val zioCliBuildNative = taskKey[Unit]("Build a native image version of the CLI App")
+  lazy val zioCliBuildNative            = taskKey[Unit]("Build a native image version of the CLI App")
   lazy val zioCliGenerateBashCompletion = taskKey[Unit]("Generate bash completion for the CLI App")
-  lazy val zioCliGenerateZshCompletion = taskKey[Unit]("Generate zsh completion for the CLI App")
-  lazy val zioCliInstallCli = taskKey[Unit]("Run the universal installer")
+  lazy val zioCliGenerateZshCompletion  = taskKey[Unit]("Generate zsh completion for the CLI App")
+  lazy val zioCliInstallCli             = taskKey[Unit]("Run the universal installer")
 
 }


### PR DESCRIPTION
closes #203. 

The package `zio.cli.sbt/sbt-zio-cli` is not currently published in maven. Somebody (other than me)  has to publish it.

This patch makes it such that `sbt publish` would include `zio.cli.sbt/sbt-zio-cli` by default. Otherwise, it can be published individually with `sbt sbtZioCli/publish`.

You can test this patch locally with `sbt publishLocal`, which would publish the artifacts to the folder `~/.ivy2/local/`.

Regardless of this PR, someone with publishing credentials should publish this package.

/claim #203 