### PR TITLE
OAuth2: Add support for refresh tokens on Github

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2.scala
@@ -218,7 +218,7 @@ private[cli] class OAuth2(provider: OAuth2Provider, file: Path, scope: List[Stri
               t.accessToken,
               t.tokenType,
               t.expiresIn.map(exp => time.plus(exp)),
-              refreshToken.orElse(t.refreshToken),
+              t.refreshToken.orElse(refreshToken),
               t.scope
             )
           )

--- a/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/oauth2/OAuth2Provider.scala
@@ -101,7 +101,19 @@ object OAuth2Provider {
         .POST(HttpRequest.BodyPublishers.noBody())
         .build()
 
-    override def refreshTokenRequest(refreshToken: String): Option[HttpRequest] = None
+    override def refreshTokenRequest(refreshToken: String): Option[HttpRequest] =
+      Some(
+        HttpRequest
+          .newBuilder()
+          .uri(
+            URI.create(
+              s"https://github.com/login/oauth/access_token?client_id=$clientId&grant_type=refresh_token&refresh_token=$refreshToken"
+            )
+          )
+          .header("Accept", "application/json")
+          .POST(HttpRequest.BodyPublishers.noBody())
+          .build()
+      )
   }
 
   final case class Google(clientId: String, clientSecret: String) extends OAuth2Provider {


### PR DESCRIPTION
Github apps have [optional](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#configuring-your-app-to-use-user-access-tokens-that-expire) expiration of access tokens, which leads to using refresh token to obtain new access token (and new refresh token). This patch adds support for refresh tokens on Github, which was previously missing.

Although the Github [documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#refreshing-a-user-access-token-with-a-refresh-token) specifies that `client_secret` is a required parameter for refreshing token, it is not required in this case for unknown reason (perhaps device flow?).

Additionally after this change, new refresh token will be used preferentially, if present in refresh token response.