### PR TITLE
Display all subcommands and pruned code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,6 +112,7 @@ lazy val sbtZioCli = project
     organization       := "zio.cli.sbt",
     scalaVersion       := Scala212,
     crossScalaVersions := Seq(Scala212),
+    publish / skip     := true,
     addSbtPlugin("org.scalameta" %% "sbt-native-image" % "0.3.2")
   )
   .enablePlugins(SbtPlugin)

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -228,6 +228,7 @@ object Command {
             val finalSynopsis = synopsisList
               .foldRight(HelpDoc.Span.empty) {
                 case (HelpDoc.Span.Text(""), span) => span
+                case (span, HelpDoc.Span.Text("")) => span
                 case (span1, span2)                => span1 + HelpDoc.Span.text(" ") + span2
               }
             List((finalSynopsis, desc.getSpan))

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -245,7 +245,7 @@ object Command {
             }
           case Map(cmd, _) =>
             subcommandsDesc(cmd, maxSynopsisLength)
-          case Subcommands(parent, _) =>
+          case Subcommands(parent, child) =>
             HelpDoc.enumeration(subcommandsDesc(parent, maxSynopsisLength), subcommandsDesc(child, maxSynopsisLength))
         }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -33,10 +33,10 @@ sealed trait Options[+A] extends Parameter { self =>
   final def ++[A1 >: A, B](that: Options[B])(implicit zippable: Zippable[A, B]): Options[zippable.Out] =
     Options.Both(self, that).map { case (a, b) => zippable.zip(a, b) }
 
-  final def |[A1 >: A](that: Options[A1]): Options[A1] = self.orElse(that)
+  final def |[A1 >: A](that: Options[A1]): Options[A1] = orElse(that)
 
   final def orElse[A1 >: A](that: Options[A1]): Options[A1] =
-    self.orElseEither(that).map(_.merge)
+    orElseEither(that).map(_.merge)
 
   final def orElseEither[B](that: Options[B]): Options[Either[A, B]] =
     Options.OrElse(self, that)
@@ -54,27 +54,27 @@ sealed trait Options[+A] extends Parameter { self =>
   // TODO : spend time to understand usage of implicit here
 
   final def as[B, C, Z](f: (B, C) => Z)(implicit ev: A <:< (B, C)): Options[Z] =
-    self.map(ev).map { case (b, c) => f(b, c) }
+    map(ev).map { case (b, c) => f(b, c) }
 
   final def as[B, C, D, Z](f: (B, C, D) => Z)(implicit ev: A <:< (B, C, D)): Options[Z] =
-    self.map(ev).map { case (b, c, d) => f(b, c, d) }
+    map(ev).map { case (b, c, d) => f(b, c, d) }
 
   final def as[B, C, D, E, Z](f: (B, C, D, E) => Z)(implicit ev: A <:< (B, C, D, E)): Options[Z] =
-    self.map(ev).map { case (b, c, d, e) => f(b, c, d, e) }
+    map(ev).map { case (b, c, d, e) => f(b, c, d, e) }
 
   final def as[B, C, D, E, F, Z](f0: (B, C, D, E, F) => Z)(implicit ev: A <:< (B, C, D, E, F)): Options[Z] =
-    self.map(ev).map { case (b, c, d, e, f) => f0(b, c, d, e, f) }
+    map(ev).map { case (b, c, d, e, f) => f0(b, c, d, e, f) }
 
   final def as[B, C, D, E, F, G, Z](
     f0: (B, C, D, E, F, G) => Z
   )(implicit ev: A <:< (B, C, D, E, F, G)): Options[Z] =
-    self.map(ev).map { case (b, c, d, e, f, g) => f0(b, c, d, e, f, g) }
+    map(ev).map { case (b, c, d, e, f, g) => f0(b, c, d, e, f, g) }
 
   final def fold[B, C, Z](
     f1: B => Z,
     f2: C => Z
   )(implicit ev: A <:< Either[B, C]): Options[Z] =
-    self.map(ev).map {
+    map(ev).map {
       case Left(b)  => f1(b)
       case Right(c) => f2(c)
     }
@@ -84,7 +84,7 @@ sealed trait Options[+A] extends Parameter { self =>
     f2: C => Z,
     f3: D => Z
   )(implicit ev: A <:< Either[Either[B, C], D]): Options[Z] =
-    self.map(ev).map {
+    map(ev).map {
       case Left(Left(b))  => f1(b)
       case Left(Right(c)) => f2(c)
       case Right(d)       => f3(d)
@@ -96,7 +96,7 @@ sealed trait Options[+A] extends Parameter { self =>
     f3: D => Z,
     f4: E => Z
   )(implicit ev: A <:< Either[Either[Either[B, C], D], E]): Options[Z] =
-    self.map(ev).map {
+    map(ev).map {
       case Left(Left(Left(b)))  => f1(b)
       case Left(Left(Right(c))) => f2(c)
       case Left(Right(d))       => f3(d)
@@ -110,7 +110,7 @@ sealed trait Options[+A] extends Parameter { self =>
     f4: E => Z,
     f5: F => Z
   )(implicit ev: A <:< Either[Either[Either[Either[B, C], D], E], F]): Options[Z] =
-    self.map(ev).map {
+    map(ev).map {
       case Left(Left(Left(Left(b))))  => f1(b)
       case Left(Left(Left(Right(c)))) => f2(c)
       case Left(Left(Right(d)))       => f3(d)
@@ -126,7 +126,7 @@ sealed trait Options[+A] extends Parameter { self =>
     f5: F => Z,
     f6: G => Z
   )(implicit ev: A <:< Either[Either[Either[Either[Either[B, C], D], E], F], G]): Options[Z] =
-    self.map(ev).map {
+    map(ev).map {
       case Left(Left(Left(Left(Left(b)))))  => f1(b)
       case Left(Left(Left(Left(Right(c))))) => f2(c)
       case Left(Left(Left(Right(d))))       => f3(d)
@@ -148,7 +148,7 @@ sealed trait Options[+A] extends Parameter { self =>
   def helpDoc: HelpDoc
 
   final def isBool: Boolean =
-    self.asInstanceOf[Options[_]] match {
+    asInstanceOf[Options[_]] match {
       case Options.Empty                   => false
       case Options.WithDefault(options, _) => options.isBool
       case Single(_, _, primType, _)       => primType.isBool
@@ -162,10 +162,10 @@ sealed trait Options[+A] extends Parameter { self =>
     Options.Map(self, (a: A) => f(a))
 
   final def mapTry[B](f: A => B): Options[B] =
-    self.mapOrFail((a: A) =>
+    mapOrFail((a: A) =>
       scala.util.Try(f(a)).toEither.left.map(e => ValidationError(ValidationErrorType.InvalidValue, p(e.getMessage)))
     )
-  final def optional: Options[Option[A]] = self.map(Some(_)).withDefault(None)
+  final def optional: Options[Option[A]] = map(Some(_)).withDefault(None)
 
   final def primitiveType: Option[PrimType[A]] =
     self match {
@@ -192,7 +192,7 @@ trait SingleModifier {
 }
 
 object Options extends OptionsPlatformSpecific {
-  case object Empty extends Options[Unit] with Pipeline { self =>
+  case object Empty extends Options[Unit] with Pipeline {
     lazy val synopsis: UsageSynopsis = UsageSynopsis.None
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], Unit)] =
@@ -207,28 +207,28 @@ object Options extends OptionsPlatformSpecific {
     override def pipeline = ("", List())
   }
 
-  final case class WithDefault[A](options: Options[A], default: A) extends Options[A] with Input { self =>
+  final case class WithDefault[A](options: Options[A], default: A) extends Options[A] with Input {
 
     override lazy val shortDesc: String = options.shortDesc
 
-    lazy val synopsis: UsageSynopsis = self.options.synopsis.optional
+    lazy val synopsis: UsageSynopsis = options.synopsis.optional
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
-      self.options
+      options
         .validate(args, conf)
         .catchSome {
-          case error if error.isOptionMissing => ZIO.succeed(args -> self.default)
+          case error if error.isOptionMissing => ZIO.succeed(args -> default)
         }
 
     override def modifySingle(f: SingleModifier): Options[A] =
-      WithDefault(self.options.modifySingle(f), self.default)
+      WithDefault(options.modifySingle(f), default)
 
     override lazy val helpDoc: HelpDoc =
       options.helpDoc.mapDescriptionList { case (span, block) =>
-        span -> (block + HelpDoc.p(s"This setting is optional. Default: '${self.default}'."))
+        span -> (block + HelpDoc.p(s"This setting is optional. Default: '${default}'."))
       }
 
-    override lazy val uid: Option[String] = self.options.uid
+    override lazy val uid: Option[String] = options.uid
 
     override def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]] =
       ZIO.succeed(
@@ -254,8 +254,8 @@ object Options extends OptionsPlatformSpecific {
 
     lazy val synopsis: UsageSynopsis =
       UsageSynopsis.Named(
-        self.names,
-        if (!self.primType.isBool) self.primType.choices.orElse(Some(self.primType.typeName)) else None
+        names,
+        if (!primType.isBool) primType.choices.orElse(Some(primType.typeName)) else None
       )
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
@@ -263,37 +263,37 @@ object Options extends OptionsPlatformSpecific {
         case head :: tail =>
           val (rest, supported) = processArg(head, tail, conf)
           if (supported) {
-            self.primType match {
+            primType match {
               case _: PrimType.Bool =>
-                self.primType
+                primType
                   .validate(None, conf)
                   .mapBoth(e => ValidationError(ValidationErrorType.InvalidValue, p(e)), rest -> _)
               case _ =>
-                self.primType
+                primType
                   .validate(rest.headOption, conf)
                   .mapBoth(e => ValidationError(ValidationErrorType.InvalidValue, p(e)), rest.drop(1) -> _)
             }
           } else if (
-            self.name.length > conf.autoCorrectLimit + 1 && AutoCorrect.levensteinDistance(
+            name.length > conf.autoCorrectLimit + 1 && AutoCorrect.levensteinDistance(
               head,
-              self.fullName,
+              fullName,
               conf
             ) <= conf.autoCorrectLimit
           ) {
             ZIO.fail(
               ValidationError(
                 ValidationErrorType.InvalidValue,
-                p(error(s"""The flag "$head" is not recognized. Did you mean ${self.fullName}?"""))
+                p(error(s"""The flag "$head" is not recognized. Did you mean ${fullName}?"""))
               )
             )
           } else {
-            self.validate(rest, conf).map { case (args, a) =>
+            validate(rest, conf).map { case (args, a) =>
               (head :: args, a)
             }
           }
         case Nil =>
           ZIO.fail(
-            ValidationError(ValidationErrorType.MissingValue, p(error(s"Expected to find ${self.fullName} option.")))
+            ValidationError(ValidationErrorType.MissingValue, p(error(s"Expected to find ${fullName} option.")))
           )
       }
 
@@ -306,39 +306,39 @@ object Options extends OptionsPlatformSpecific {
           else (args, false)
         } else (args, false)
 
-      if (conf.caseSensitive) process(self.names.contains)
-      else process(s => self.names.exists(_.equalsIgnoreCase(s)))
+      if (conf.caseSensitive) process(names.contains)
+      else process(s => names.exists(_.equalsIgnoreCase(s)))
     }
 
-    lazy val uid: Option[String] = Some(self.fullName)
+    lazy val uid: Option[String] = Some(fullName)
 
     private def makeFullName(s: String): (Boolean, String) = if (s.length == 1) (true, "-" + s) else (false, "--" + s)
 
-    lazy val names: List[String] = (self.name :: self.aliases.toList).map(self.makeFullName).sortBy(!_._1).map(_._2)
+    lazy val names: List[String] = (name :: aliases.toList).map(makeFullName).sortBy(!_._1).map(_._2)
 
-    private lazy val fullName: String = self.makeFullName(self.name)._2
+    private lazy val fullName: String = makeFullName(name)._2
 
     override lazy val helpDoc: HelpDoc =
-      HelpDoc.DescriptionList(List(self.synopsis.helpDoc.getSpan -> (p(self.primType.helpDoc) + self.description)))
+      HelpDoc.DescriptionList(List(synopsis.helpDoc.getSpan -> (p(primType.helpDoc) + description)))
 
     override def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]] = for {
-      _ <- validate(List(self.names.head, input), conf)
-    } yield List(self.names.head, input)
+      _ <- validate(List(names.head, input), conf)
+    } yield List(names.head, input)
   }
 
   final case class OrElse[A, B](left: Options[A], right: Options[B]) extends Options[Either[A, B]] with Alternatives {
-    self =>
-    override def modifySingle(f: SingleModifier): Options[Either[A, B]] =
-      OrElse(left.modifySingle(f), self.right.modifySingle(f))
 
-    lazy val synopsis: UsageSynopsis = UsageSynopsis.Alternation(self.left.synopsis, self.right.synopsis)
+    override def modifySingle(f: SingleModifier): Options[Either[A, B]] =
+      OrElse(left.modifySingle(f), right.modifySingle(f))
+
+    lazy val synopsis: UsageSynopsis = UsageSynopsis.Alternation(left.synopsis, right.synopsis)
 
     override def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], Either[A, B])] =
-      self.left
+      left
         .validate(args, conf)
         .foldZIO(
           err1 =>
-            self.right
+            right
               .validate(args, conf)
               .foldZIO[Any, ValidationError, (List[String], Either[A, B])](
                 err2 =>
@@ -354,7 +354,7 @@ object Options extends OptionsPlatformSpecific {
                 success => ZIO.succeed((success._1, Right(success._2)))
               ),
           r =>
-            self.right
+            right
               .validate(r._1, conf)
               .foldZIO(
                 _ => ZIO.succeed((r._1, Left(r._2))),
@@ -363,16 +363,16 @@ object Options extends OptionsPlatformSpecific {
                     ValidationError(
                       ValidationErrorType.InvalidValue,
                       p(
-                        error(s"Options collision detected. You can only specify either ${self.left} or ${self.right}.")
+                        error(s"Options collision detected. You can only specify either ${left} or ${right}.")
                       )
                     )
                   )
               )
         )
 
-    override lazy val helpDoc: HelpDoc = self.left.helpDoc + self.right.helpDoc
+    override lazy val helpDoc: HelpDoc = left.helpDoc + right.helpDoc
 
-    override lazy val uid: Option[String] = self.left.uid.toList ++ self.right.uid.toList match {
+    override lazy val uid: Option[String] = left.uid.toList ++ right.uid.toList match {
       case Nil  => None
       case list => Some(list.mkString(", "))
     }
@@ -380,18 +380,18 @@ object Options extends OptionsPlatformSpecific {
     override val alternatives = List(left, right)
   }
 
-  final case class Both[A, B](left: Options[A], right: Options[B]) extends Options[(A, B)] with Pipeline { self =>
+  final case class Both[A, B](left: Options[A], right: Options[B]) extends Options[(A, B)] with Pipeline {
     override def modifySingle(f: SingleModifier): Options[(A, B)] =
-      Both(self.left.modifySingle(f), self.right.modifySingle(f))
+      Both(left.modifySingle(f), right.modifySingle(f))
 
-    lazy val synopsis: UsageSynopsis = self.left.synopsis + self.right.synopsis
+    lazy val synopsis: UsageSynopsis = left.synopsis + right.synopsis
 
     override def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], (A, B))] =
       for {
-        tuple <- self.left
+        tuple <- left
                    .validate(args, conf)
                    .catchAll(err1 =>
-                     self.right
+                     right
                        .validate(args, conf)
                        .foldZIO(
                          err2 => ZIO.fail(ValidationError(ValidationErrorType.MissingValue, err1.error + err2.error)),
@@ -399,38 +399,38 @@ object Options extends OptionsPlatformSpecific {
                        )
                    )
         (args, a) = tuple
-        tuple    <- self.right.validate(args, conf)
+        tuple    <- right.validate(args, conf)
         (args, b) = tuple
       } yield args -> (a -> b)
 
-    override lazy val helpDoc: HelpDoc = self.left.helpDoc + self.right.helpDoc
+    override lazy val helpDoc: HelpDoc = left.helpDoc + right.helpDoc
 
-    override lazy val uid: Option[String] = self.left.uid.toList ++ self.right.uid.toList match {
+    override lazy val uid: Option[String] = left.uid.toList ++ right.uid.toList match {
       case Nil  => None
       case list => Some(list.mkString(", "))
     }
 
-    override def pipeline = ("", List(self.left, self.right))
+    override def pipeline = ("", List(left, right))
 
   }
 
   final case class Map[A, B](value: Options[A], f: A => Either[ValidationError, B])
       extends Options[B]
       with Pipeline
-      with Wrap { self =>
+      with Wrap {
 
     override lazy val shortDesc = value.shortDesc
 
-    override def modifySingle(f0: SingleModifier): Options[B] = Map(self.value.modifySingle(f0), self.f)
+    override def modifySingle(f0: SingleModifier): Options[B] = Map(value.modifySingle(f0), f)
 
-    lazy val synopsis: UsageSynopsis = self.value.synopsis
+    lazy val synopsis: UsageSynopsis = value.synopsis
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], B)] =
-      self.value.validate(args, conf).flatMap(r => self.f(r._2).fold(e => ZIO.fail(e), s => ZIO.succeed(r._1 -> s)))
+      value.validate(args, conf).flatMap(r => f(r._2).fold(e => ZIO.fail(e), s => ZIO.succeed(r._1 -> s)))
 
-    override lazy val uid: Option[String] = self.value.uid
+    override lazy val uid: Option[String] = value.uid
 
-    override lazy val helpDoc: HelpDoc = self.value.helpDoc
+    override lazy val helpDoc: HelpDoc = value.helpDoc
 
     override def pipeline = ("", List(value))
 
@@ -440,15 +440,14 @@ object Options extends OptionsPlatformSpecific {
   final case class KeyValueMap(argumentOption: Options.Single[String])
       extends Options[Predef.Map[String, String]]
       with Input {
-    self =>
 
     override lazy val shortDesc: String = argumentOption.shortDesc
 
-    override def helpDoc: HelpDoc = self.argumentOption.helpDoc
+    override def helpDoc: HelpDoc = argumentOption.helpDoc
 
-    override def synopsis: UsageSynopsis = self.argumentOption.synopsis
+    override def synopsis: UsageSynopsis = argumentOption.synopsis
 
-    override def uid: Option[String] = self.argumentOption.uid
+    override def uid: Option[String] = argumentOption.uid
 
     override def validate(
       args: List[String],
@@ -467,7 +466,7 @@ object Options extends OptionsPlatformSpecific {
             (if (caseSensitive) argOpt else argOpt.toLowerCase)
 
         val argOptSwitchNameAndAliases =
-          (self.argumentOption.name +: self.argumentOption.aliases)
+          (argumentOption.name +: argumentOption.aliases)
             .map(withHyphen)
             .toSet
 
@@ -532,7 +531,7 @@ object Options extends OptionsPlatformSpecific {
         (remains, (first :: pairs).toMap)
       }
 
-      self.argumentOption
+      argumentOption
         .validate(args, conf)
         .flatMap { case (input, first) =>
           processArguments(input, first, conf)
@@ -540,7 +539,7 @@ object Options extends OptionsPlatformSpecific {
     }
 
     override private[cli] def modifySingle(f: SingleModifier) =
-      Options.keyValueMap(f(self.argumentOption))
+      Options.keyValueMap(f(argumentOption))
 
     override def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]] =
       for {

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -237,11 +237,11 @@ object Options extends OptionsPlatformSpecific {
     override lazy val helpDoc: HelpDoc =
       options.helpDoc.mapDescriptionList { case (span, block) =>
         val optionalDescription =
-          self.default.asInstanceOf[Any] match {
+          default.asInstanceOf[Any] match {
             case None =>
               HelpDoc.p(s"This setting is optional.")
             case _ =>
-              HelpDoc.p(s"This setting is optional. Default: '${self.default}'.")
+              HelpDoc.p(s"This setting is optional. Default: '${default}'.")
           }
         span -> (block + optionalDescription)
       }
@@ -273,8 +273,8 @@ object Options extends OptionsPlatformSpecific {
 
     lazy val synopsis: UsageSynopsis =
       UsageSynopsis.Named(
-        self.names,
-        if (!self.primType.isBool) self.primType.choices.orElse(Some(placeholder)) else None
+        names,
+        if (!primType.isBool) primType.choices.orElse(Some(placeholder)) else None
       )
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
@@ -341,10 +341,10 @@ object Options extends OptionsPlatformSpecific {
       HelpDoc.DescriptionList(List(synopsis.helpDoc.getSpan -> (p(primType.helpDoc) + description)))
 
     override def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]] = for {
-      _ <- validate(List(self.names.head, input), conf)
-    } yield List(self.names.head, input)
+      _ <- validate(List(names.head, input), conf)
+    } yield List(names.head, input)
 
-    private def placeholder: String = "<" + self.pseudoName.getOrElse(self.primType.typeName) + ">"
+    private def placeholder: String = "<" + pseudoName.getOrElse(primType.typeName) + ">"
   }
 
   final case class OrElse[A, B](left: Options[A], right: Options[B]) extends Options[Either[A, B]] with Alternatives {

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -244,6 +244,20 @@ object CommandSpec extends ZIOSpecDefault {
             containsString("this is some help with command")
           )
         )
+      },
+      suite("correct display of helpDoc") {
+
+        val child2 = Command("child2").withHelp("help 2") | Command("child3").withHelp("help 3")
+
+        val child1 = Command("child1").subcommands(child2).withHelp("help 1")
+
+        val parent = Command("parent").subcommands(child1)
+        
+        test("test helpDoc list subcommands of subcommands")(
+          assert(parent.helpDoc.toPlaintext())(
+            containsString("this is some help with command")
+          )
+        )
       }
     ),
     test("cmd opts -- args") {

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -255,7 +255,9 @@ object CommandSpec extends ZIOSpecDefault {
 
         test("test helpDoc list subcommands of subcommands")(
           assert(parent.helpDoc.toPlaintext())(
-            containsString("this is some help with command")
+            containsString("- child1         help 2") &&
+              containsString("- child1 child2  help 2") &&
+              containsString("- child1 child3  help 3")
           )
         )
       }

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -252,7 +252,7 @@ object CommandSpec extends ZIOSpecDefault {
         val child1 = Command("child1").subcommands(child2).withHelp("help 1")
 
         val parent = Command("parent").subcommands(child1)
-        
+
         test("test helpDoc list subcommands of subcommands")(
           assert(parent.helpDoc.toPlaintext())(
             containsString("this is some help with command")

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -255,7 +255,7 @@ object CommandSpec extends ZIOSpecDefault {
 
         test("test helpDoc list subcommands of subcommands")(
           assert(parent.helpDoc.toPlaintext())(
-            containsString("- child1         help 2") &&
+            containsString("- child1         help 1") &&
               containsString("- child1 child2  help 2") &&
               containsString("- child1 child3  help 3")
           )


### PR DESCRIPTION
/claim #113

A command with tree structure
```
parent
    └── child1
        ├── child2
        └── child3
```

would have the following `helpDoc`:
```
COMMANDS

  -  child1         help1
  -  child1 child2  help2
  -  child1 child3  help3
```

Also, I have deleted some unnecesary `self` in `Args`, `Options` and `Commands`.