### PR TITLE
Fixed regex for "-"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'master' ]
+    branches: [ 'fixed-regex5' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'master' ]
+    branches: [ 'fixed-regex-merge' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '11', '17' ]
-        scala: [ '2.12.17', '2.13.10', '3.3.0' ]
+        scala: [ '2.12.18', '2.13.11', '3.3.0' ]
         platform: [ 'JVM', 'JS', 'Native' ]
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'fixed-regex4' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'fixed-regex3' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'fixed-regex-merge' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'fixed-regex5' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'fixed-regex2' ]
+    branches: [ 'fixed-regex3' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'master' ]
+    branches: [ 'fixed-regex4' ]
   release:
     types:
       - published

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -11,8 +11,8 @@ import scalafix.sbt.ScalafixPlugin.autoImport._
 
 object BuildHelper {
 
-  val Scala212 = "2.12.17"
-  val Scala213 = "2.13.10"
+  val Scala212 = "2.12.18"
+  val Scala213 = "2.13.11"
   val Scala3   = "3.3.0"
 
   val SilencerVersion = "1.17.13"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                 % "1.5.8")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"              % "0.10.3")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"              % "0.11.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"             % "0.11.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"                % "0.5.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"            % "1.5.11")

--- a/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -10,7 +10,7 @@ private[cli] object OAuth2PlatformSpecific {
     provider: OAuth2Provider,
     scope: List[String],
     auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
-    args: List[String],
+    args: Predef.Map[String, List[String]],
     conf: CliConfig
   ): IO[ValidationError, (List[String], OAuth2Token)] =
     ZIO.dieMessage(

--- a/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -12,7 +12,7 @@ private[cli] object OAuth2PlatformSpecific {
     auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
     args: Predef.Map[String, List[String]],
     conf: CliConfig
-  ): IO[ValidationError, (List[String], OAuth2Token)] =
+  ): IO[ValidationError, OAuth2Token] =
     ZIO.dieMessage(
       "OAuth2 support is not currently implemented for Scala.js. If you are interested in adding support, please open a pull request at https://github.com/zio/zio-cli."
     )

--- a/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -10,13 +10,12 @@ private[cli] object OAuth2PlatformSpecific {
     provider: OAuth2Provider,
     scope: List[String],
     auxiliaryOptions: Options[OAuth2AuxiliaryOptions],
-    args: List[String],
+    args: Predef.Map[String, List[String]],
     conf: CliConfig
-  ): IO[ValidationError, (List[String], OAuth2Token)] =
-    auxiliaryOptions.validate(args, conf).flatMap { case (args, aux) =>
+  ): IO[ValidationError, OAuth2Token] =
+    auxiliaryOptions.validate(args, conf).flatMap { case aux =>
       new OAuth2(provider, aux.file, scope).loadOrAuthorize
         .mapError(ex => ValidationError(ValidationErrorType.InvalidValue, p(ex.getMessage)))
-        .map(token => (args, token))
     }
 
   def findProvider(opt: Options[Any]): Option[OAuth2Provider] =

--- a/zio-cli/jvm/src/test/scala/zio/cli/figlet/FigFontRenderReportSpec.scala
+++ b/zio-cli/jvm/src/test/scala/zio/cli/figlet/FigFontRenderReportSpec.scala
@@ -60,7 +60,7 @@ object FigFontRenderReportSpec extends ZIOSpecDefault {
           val path = Files.createTempFile("figlet-report", ".md")
           (path, Files.newBufferedWriter(path))
         }
-      } { case (_, w) =>
+      } { _ =>
         ZIO.unit
       } { case (path, w) =>
         ZIO.attempt {

--- a/zio-cli/jvm/src/test/scala/zio/cli/figlet/FigFontRendererJvmSpec.scala
+++ b/zio-cli/jvm/src/test/scala/zio/cli/figlet/FigFontRendererJvmSpec.scala
@@ -9,9 +9,8 @@ object FigFontRendererJvmSpec extends ZIOSpecDefault {
   def spec = suite("FigFontRendererJvmSpec")(
     test("ZIO-CLI!!! with standard.flf") {
       for {
-        font_        <- FigFont.fromResource("standard.flf", getClass.getClassLoader)
-        font: FigFont = font_ // TODO IJ cross-platform projects issue
-        r             = render(font, "ZIO-\nCLI!!!")
+        font <- FigFont.fromResource("standard.flf", getClass.getClassLoader)
+        r     = render(font, "ZIO-\nCLI!!!")
       } yield {
         assertTextBlock(
           r,

--- a/zio-cli/shared/src/main/scala/zio/cli/Args.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Args.scala
@@ -95,6 +95,9 @@ object Args {
 
     lazy val synopsis: UsageSynopsis = UsageSynopsis.Named(List(name), self.primType.choices)
 
+    override def parse(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], List[String])] =
+      ZIO.succeed((Nil, Nil))
+
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
       (args match {
         case head :: tail => self.primType.validate(Some(head), conf).mapBoth(text => HelpDoc.p(text), a => tail -> a)
@@ -192,6 +195,9 @@ object Args {
     lazy val maxSize: Int = self.max.getOrElse(Int.MaxValue / 2) * self.value.maxSize
 
     lazy val minSize: Int = self.min.getOrElse(0) * value.minSize
+
+    override def parse(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], List[String])] =
+      ZIO.succeed((Nil, Nil))
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], List[A])] = {
       val min1 = min.getOrElse(0)

--- a/zio-cli/shared/src/main/scala/zio/cli/CliConfig.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliConfig.scala
@@ -12,7 +12,8 @@ import zio.{URIO, ZIO}
  */
 final case class CliConfig(
   caseSensitive: Boolean,
-  autoCorrectLimit: Int
+  autoCorrectLimit: Int,
+  finalCheckBuiltIn: Boolean = true
 ) {
   def normalizeCase(text: String): String = if (caseSensitive) text else text.toLowerCase()
 
@@ -28,7 +29,7 @@ object CliConfig {
   /**
    * The default options are case sensitive parsing
    */
-  val default: CliConfig = CliConfig(caseSensitive = false, autoCorrectLimit = 2)
+  val default: CliConfig = CliConfig(caseSensitive = false, autoCorrectLimit = 2, finalCheckBuiltIn = true)
 
   val cliConfig: URIO[CliConfig, CliConfig] = ZIO.service
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -160,8 +160,8 @@ object Command {
         } yield CommandDirective.userDefined(argsLeftover, (optionsType, argsType))
 
       val exhaustiveSearch =
-        if (args.contains("--help") || args.contains("-h")) parse(List("--help"), conf)
-        else if (args.contains("--wizard") || args.contains("-w")) parse(List("--wizard"), conf)
+        if (args.contains("--help") || args.contains("-h")) parse(List(name, "--help"), conf)
+        else if (args.contains("--wizard") || args.contains("-w")) parse(List(name, "--wizard"), conf)
         else ZIO.fail(
           ValidationError(
             ValidationErrorType.CommandMismatch,

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -416,11 +416,10 @@ object Ap extends ZIOAppDefault {
           .map { _ => () }
       )
 
-  val commands = List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
+  val c = List("--help")
+  //List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
   val run = (for {
-    parsed <- ZIO.foreach(commands){ case c => 
-      command.parse(c, CliConfig.default)
-    }
+    parsed <- command.parse("test" :: c, CliConfig.default)
     _ <- Console.printLine(parsed)
   } yield ()).catchSome {
     case _: ValidationError => Console.printLine("valerr")

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -400,30 +400,3 @@ object Command {
   )(implicit ev: Reducable[Unit, Unit]): Command[ev.Out] =
     Single(name, HelpDoc.empty, Options.none, Args.none).map(ev.fromTuple2(_))
 }
-
-import zio._
-import zio.cli._
-
-object Ap extends ZIOAppDefault {
-
-  private val param = Options.text("a")
-
-  val command = Command("test", param)
-
-  val command2 = Command("test", param).subcommands(
-    Command("a")
-      .subcommands(
-        Command("b")
-      )
-      .map(_ => ())
-  )
-
-  val c = List("--wizard")
-  // List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
-  val run = (for {
-    parsed <- command.parse("test" :: c, CliConfig.default)
-    _      <- Console.printLine(parsed)
-  } yield ()).catchSome { case ValidationError(_, err) =>
-    Console.printLine(err.toPlaintext())
-  }
-}

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -94,6 +94,17 @@ object Command {
         )
     }
 
+  // Sums the list associated with the same key.
+  private def merge(map1: Predef.Map[String, List[String]], map2: List[(String, List[String])]): Predef.Map[String, List[String]] =
+    map2 match {
+      case Nil => map1
+      case head :: tail =>
+        map1.updatedWith(head._1){
+          case None => Some(head._2)
+          case Some(list) => Some(list ++ head._2)
+        }
+    }
+
   private def matchOptions(input: List[String], options: List[Options[_] with Input], conf: CliConfig): IO[ValidationError, (List[String], List[Options[_] with Input], Predef.Map[String, List[String]])] =
     (input, options) match {
       case (Nil, _) => ZIO.succeed((Nil, options, Predef.Map.empty))
@@ -104,7 +115,7 @@ object Command {
           (otherArgs, otherOptions, map1) = tuple1
           tuple2 <- matchOptions(otherArgs, otherOptions, conf)
           (otherArgs, unusedOptions, map2) = tuple2
-        } yield (otherArgs, unusedOptions, map1 ++ map2)
+        } yield (otherArgs, unusedOptions, merge(map1, map2.toList))
     }
     
     

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -406,7 +406,7 @@ import zio.cli._
 
 object Ap extends ZIOAppDefault {
 
-  private val param = Options.text("param")
+  private val param = Options.text("a")
 
   val command = Command("test", param)
 
@@ -418,7 +418,7 @@ object Ap extends ZIOAppDefault {
           .map { _ => () }
       )
 
-  val c = List("--wizard")
+  val c = List("-a", "--help")
   //List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
   val run = (for {
     parsed <- command.parse( "test" :: c, CliConfig.default)

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -418,7 +418,7 @@ object Ap extends ZIOAppDefault {
       .map(_ => ())
   )
 
-  val c = List("--shell-completion-index", "3", "--shell-type", "sh") 
+  val c = List("--shell-completion-index", "3", "--shell-type", "sh")
   // List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
   val run = (for {
     parsed <- command.parse("test" :: c, CliConfig.default)

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -418,7 +418,7 @@ object Ap extends ZIOAppDefault {
       .map(_ => ())
   )
 
-  val c = List("--shell-completion-index", "3", "--shell-type", "sh")
+  val c = List("--wizard")
   // List(List("--help"), List("asd", "--help"), List("asd", "a", "--help"), List("--help"), List("--wizard"), List("test", "--wizard"))
   val run = (for {
     parsed <- command.parse("test" :: c, CliConfig.default)

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -209,15 +209,8 @@ object Options extends OptionsPlatformSpecific {
               }
             case (parsed, leftover) => 
               parsed match {
-                case name :: Nil =>
-                  ZIO.succeed((leftover, tail, Predef.Map(name -> Nil)))
-                case name :: value :: Nil =>
-                  ZIO.succeed((leftover, tail, Predef.Map(name -> List(value))))
-                case _ =>
-                  ZIO.fail(ValidationError(
-                    ValidationErrorType.CommandMismatch,
-                    HelpDoc.p(s"Non-valid input")
-                  ))
+                case name :: values =>
+                  ZIO.succeed((leftover, tail, Predef.Map(name -> values)))
               }
           }
         ).catchSome {

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -235,11 +235,6 @@ object Options extends OptionsPlatformSpecific {
                   (otherArgs, otherOptions, map) = tuple
                   _ <- ZIO.when(map.isEmpty)(ZIO.fail(e))
                 } yield (otherArgs, head :: otherOptions, map)
-                findOptions(input, tail, conf).map {
-                  case (otherArgs, otherOptions, map) => (otherArgs, head :: otherOptions, map)
-                }.catchSome {
-                  case _ => ZIO.fail(e)
-                }
               case _ => ZIO.fail(e)
             }
             

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -265,7 +265,7 @@ object Options extends OptionsPlatformSpecific {
           .catchAll(e => ZIO.succeed((Some(e), input, Predef.Map.empty)))
     }
 
-  def validate[A](options: Options[A], args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
+  def validate[A](options: Options[A], args: List[String], conf: CliConfig): IO[ValidationError, (Option[ValidationError], List[String], A)] =
     for {
       matched <- matchOptions(args, options.flatten, conf)
       (error, commandArgs, matchedOptions) = matched
@@ -276,7 +276,7 @@ object Options extends OptionsPlatformSpecific {
             case None => ZIO.fail(e)
           }
       }
-    } yield (commandArgs, a)
+    } yield (error, commandArgs, a)
 
   case object Empty extends Options[Unit] with Pipeline { self =>
     lazy val synopsis: UsageSynopsis = UsageSynopsis.None

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -553,7 +553,7 @@ object Options extends OptionsPlatformSpecific {
             right
               .validate(args, conf)
               .foldZIO(
-                _ => ZIO.succeed((r._1, Left(r._2))),
+                _ => ZIO.succeed(Left(a)),
                 _ => {
                   // `uid` will only be None for Options.Empty. Which means the user would
                   // have had to purposefully compose Options.Empty | otherArgument.

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -228,6 +228,13 @@ object Options extends OptionsPlatformSpecific {
                   case (otherArgs, otherOptions, map) => (otherArgs, head :: otherOptions, map)
                 }
               case ValidationErrorType.CorrectedFlag =>
+                for {
+                  tuple <- findOptions(input, tail, conf).catchSome {
+                    case _ => ZIO.fail(e)
+                  }
+                  (otherArgs, otherOptions, map) = tuple
+                  _ <- ZIO.when(map.isEmpty)(ZIO.fail(e))
+                } yield (otherArgs, head :: otherOptions, map)
                 findOptions(input, tail, conf).map {
                   case (otherArgs, otherOptions, map) => (otherArgs, head :: otherOptions, map)
                 }.catchSome {

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -268,8 +268,8 @@ object Options extends OptionsPlatformSpecific {
     map2 match {
       case Nil => map1
       case head :: tail => {
-        //replace with updatedWith for Scala 2.13
-        val newMap = map1.get(head._1) match{
+        // replace with updatedWith for Scala 2.13
+        val newMap = map1.get(head._1) match {
           case None       => map1 + head
           case Some(elem) => map1.updated(head._1, elem ++ head._2)
         }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -675,7 +675,7 @@ object Options extends OptionsPlatformSpecific {
         }
       }
 
-      ZIO.succeed(loop(args -> Nil))
+      ZIO.succeed(loop(Nil -> args))
       
     }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -722,9 +722,17 @@ object Options extends OptionsPlatformSpecific {
   def boolean(name: String, ifPresent: Boolean, negationName: String, negationNames: String*): Options[Boolean] =
     makeBoolean(name, ifPresent, negationName :: negationNames.toList)
 
-  private def makeBoolean(name: String, ifPresent: Boolean, negationNames: List[String]): Options[Boolean] = {
+  /**
+   * Creates a boolean flag with the specified name, which, if present, will produce the specified constant boolean
+   * value. Negation names may be specified to explicitly invert the boolean value of this option.
+   * An alias might be specified to substitute the name.
+   */
+  def boolean(name: String, alias: String, ifPresent: Boolean,negationName: String, negationNames: String*): Options[Boolean] =
+    makeBoolean(name, ifPresent, negationName :: negationNames.toList, alias :: Nil)
 
-    val option = Single(name, Vector.empty, PrimType.Bool(Some(ifPresent)))
+  private def makeBoolean(name: String, ifPresent: Boolean, negationNames: List[String], aliases: List[String] = Nil): Options[Boolean] = {
+
+    val option = Single(name, aliases.toVector, PrimType.Bool(Some(ifPresent)))
 
     negationNames match {
       case Nil =>

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -337,7 +337,7 @@ object Options extends OptionsPlatformSpecific {
            }
     } yield (error, commandArgs, a)
 
-  case object Empty extends Options[Unit] with Pipeline { self =>
+  case object Empty extends Options[Unit] with Pipeline {
     lazy val synopsis: UsageSynopsis = UsageSynopsis.None
 
     override def flatten: List[Options[_] with Input] = Nil
@@ -649,7 +649,7 @@ object Options extends OptionsPlatformSpecific {
 
   final case class KeyValueMap(argumentOption: Options.Single[String])
       extends Options[Predef.Map[String, String]]
-      with Input {
+      with Input { self =>
 
     override lazy val shortDesc: String = argumentOption.shortDesc
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -549,7 +549,6 @@ object Options extends OptionsPlatformSpecific {
         .foldZIO(
           err1 =>
             right
-            right
               .validate(args, conf)
               .mapBoth(
                 err2 =>

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -203,15 +203,12 @@ object Options extends OptionsPlatformSpecific {
       case head :: tail =>
         head.parse(input, conf).flatMap(
             parsed => parsed match {
-            case (Nil, input) => 
+            case (Nil, leftover) => 
               findOptions(input, tail, conf).map {
                 case (otherArgs, otherOptions, map) => (otherArgs, head :: otherOptions, map)
               }
-            case (parsed, leftover) => 
-              parsed match {
-                case name :: values =>
+            case (name :: values, leftover) => 
                   ZIO.succeed((leftover, tail, Predef.Map(name -> values)))
-              }
           }
         ).catchSome {
           case e@ValidationError(validationErrorType, error) =>

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -197,6 +197,10 @@ trait SingleModifier {
 
 object Options extends OptionsPlatformSpecific {
 
+  /**
+   * Returns the leftover arguments, leftover options and a `Map`linking the first argument with its values if it
+   * corresponds to an option flag.
+   */
   private def findOptions(
     input: List[String],
     options: List[Options[_] with Input],
@@ -277,6 +281,10 @@ object Options extends OptionsPlatformSpecific {
       }
     }
 
+  /**
+   * Returns a possible `ValidationError` when parsing the commands, leftover arguments from `input` and a `Map` linking
+   * each flag with its values.
+   */
   private def matchOptions(
     input: List[String],
     options: List[Options[_] with Input],
@@ -296,6 +304,12 @@ object Options extends OptionsPlatformSpecific {
           .catchAll(e => ZIO.succeed((Some(e), input, Predef.Map.empty)))
     }
 
+  /**
+   * `Options.validate` parses `args` for `options and returns an `Option[ValidationError]`, the leftover arguments and
+   * the constructed value of type `A`. The possible error inside `Option[ValidationError]` would only be triggered if
+   * there is an error when parsing the `Args` of a `Command`. This is because `ValidationErrors` are used to control
+   * the end of the args corresponding to options.
+   */
   def validate[A](
     options: Options[A],
     args: List[String],

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -616,19 +616,17 @@ object Options extends OptionsPlatformSpecific {
 
       def extractKeyValue(
         keyValue: String
-      ): IO[ValidationError, (String, String)] = (
-        keyValue.trim.split("=") match {
-          case Array(key, value) =>
-            ZIO.succeed((key -> value))
-          case _ =>
-            ZIO.fail(
+      ): IO[ValidationError, (String, String)] = 
+        keyValue.trim.span(_ != '=') match {
+          case (_, "") => ZIO.fail(
               ValidationError(
                 ValidationErrorType.InvalidArgument,
                 p(error(s"Expected a key/value pair but got '$keyValue'."))
               )
             )
+          case (key, value) =>
+            ZIO.succeed((key -> value.tail))
         }
-      )
       
 
       argumentOption

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -681,14 +681,16 @@ object Options extends OptionsPlatformSpecific {
           // `input` can be in the form of "-d key1=value1 -d key2=value2"
           case switch :: keyValueString :: tail if names.contains(conf.normalizeCase(switch)) =>
             keyValueString.trim.span(_ != '=') match {
-              case (_, "") => acc
+              case (_, "")  => acc
+              case (_, "=") => acc
               case (key, value) =>
                 loop((keyValueString.trim :: pairs) -> tail)
             }
           // Or, it can be in the form of "-d key1=value1 key2=value2"
           case keyValueString :: tail =>
             keyValueString.trim.span(_ != '=') match {
-              case (_, "") => acc
+              case (_, "")  => acc
+              case (_, "=") => acc
               case (key, value) =>
                 loop((keyValueString.trim :: pairs) -> tail)
             }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -628,6 +628,7 @@ object Options extends OptionsPlatformSpecific {
       } yield uid.getOrElse("") :: input.split(" ").toList
   }
 
+  
   final case class OAuth2Options(
     provider: OAuth2Provider,
     scope: List[String],

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -550,8 +550,7 @@ object Options extends OptionsPlatformSpecific {
     ): IO[ValidationError, Predef.Map[String, String]] = {
 
       def extractKeyValue(
-        keyValue: String,
-        conf: CliConfig
+        keyValue: String
       ): IO[ValidationError, (String, String)] = (
         keyValue.trim.split("=") match {
           case Array(key, value) =>
@@ -573,13 +572,13 @@ object Options extends OptionsPlatformSpecific {
             case e@ValidationError(errorType, _) => errorType match {
               case ValidationErrorType.KeyValuesDetected(list) =>
                 ZIO.foreach(list) {
-                  case keyValue => extractKeyValue(keyValue, conf)
+                  case keyValue => extractKeyValue(keyValue)
                 }.map(_.toMap)
               case _ => 
                 ZIO.fail(e)
             }
           },
-          keyValue => extractKeyValue(keyValue, conf).map(List(_).toMap)
+          keyValue => extractKeyValue(keyValue).map(List(_).toMap)
         )
     }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -268,9 +268,10 @@ object Options extends OptionsPlatformSpecific {
     map2 match {
       case Nil => map1
       case head :: tail => {
-        val newMap = map1.updatedWith(head._1) {
-          case None       => Some(head._2)
-          case Some(list) => Some(list ++ head._2)
+        //replace with updatedWith for Scala 2.13
+        val newMap = map1.get(head._1) match{
+          case None       => map1 + head
+          case Some(elem) => map1.updated(head._1, elem ++ head._2)
         }
         merge(newMap, tail)
       }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -245,11 +245,13 @@ object Options extends OptionsPlatformSpecific {
   private def merge(map1: Predef.Map[String, List[String]], map2: List[(String, List[String])]): Predef.Map[String, List[String]] =
     map2 match {
       case Nil => map1
-      case head :: tail =>
-        map1.updatedWith(head._1){
+      case head :: tail => {
+        val newMap = map1.updatedWith(head._1){
           case None => Some(head._2)
           case Some(list) => Some(list ++ head._2)
         }
+      	merge(newMap, tail)
+      }
     }
 
   private def matchOptions(input: List[String], options: List[Options[_] with Input], conf: CliConfig): IO[Nothing, (Option[ValidationError], List[String], Predef.Map[String, List[String]])] =
@@ -364,7 +366,7 @@ object Options extends OptionsPlatformSpecific {
       } match {
         case Nil => 
           ZIO.fail(
-            ValidationError(ValidationErrorType.MissingValue, p(error(s"Expected to find ${fullName} option1.")))
+            ValidationError(ValidationErrorType.MissingValue, p(error(s"Expected to find ${fullName} option.")))
           )
         case head :: Nil =>
           head match {
@@ -417,12 +419,12 @@ object Options extends OptionsPlatformSpecific {
                 else ZIO.fail(
                     ValidationError(
                       ValidationErrorType.MissingFlag,
-                      p(error(s"Expected to find ${fullName} option2."))
+                      p(error(s"Expected to find ${fullName} option."))
                     )
                   )
         case Nil =>
           ZIO.fail(
-            ValidationError(ValidationErrorType.MissingFlag, p(error(s"Expected to find ${fullName} option0.")))
+            ValidationError(ValidationErrorType.MissingFlag, p(error(s"Expected to find ${fullName} option.")))
           )
       }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -678,7 +678,7 @@ object Options extends OptionsPlatformSpecific {
       args match {
         case switch :: tail if names.contains(conf.normalizeCase(switch)) =>
           ZIO.succeed(loop(List(switch) -> args))
-        case _ => Nil -> args
+        case _ => ZIO.succeed(Nil -> args)
       }
       
     }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -251,7 +251,9 @@ object Options extends OptionsPlatformSpecific {
       case flag :: otherFlags => for {
         tuple1 <- findOptions(flag :: Nil, options, conf)
         (_, opts1, map1) = tuple1
-        tuple2 <- matchUnclustered(otherFlags, tail, opts1, conf)
+        tuple2 <- 
+          if(map1.isEmpty) ZIO.fail(ValidationError(ValidationErrorType.UnclusteredFlag(Nil, tail), HelpDoc.empty))
+          else matchUnclustered(otherFlags, tail, opts1, conf)
         (_, opts2, map2) = tuple2
       } yield (tail, opts2, merge(map1, map2.toList))
     }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -271,10 +271,10 @@ object Options extends OptionsPlatformSpecific {
     for {
       matched <- matchOptions(args, options.flatten, conf)
       (error, commandArgs, matchedOptions) = matched
-      a <- options.validate(matchedOptions, conf).catchSome {
+      a <- options.validate(matchedOptions, conf).catchAll {
         case e =>
           error match {
-            case Some(err) => ZIO.fail(e)
+            case Some(err) => ZIO.fail(err)
             case None => ZIO.fail(e)
           }
       }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -698,8 +698,11 @@ object Options extends OptionsPlatformSpecific {
       }
 
       args match {
-        case switch :: tail if names.contains(conf.normalizeCase(switch)) =>
-          ZIO.succeed(loop(List(switch) -> args))
+        case switch :: tail if names.contains(switch) =>
+          loop(Nil -> args) match {
+            case (Nil, leftover)       => ZIO.succeed(Nil -> args)
+            case (keyValues, leftover) => ZIO.succeed((switch :: keyValues) -> leftover)
+          }
         case _ => ZIO.succeed(Nil -> args)
       }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -258,7 +258,8 @@ object Options extends OptionsPlatformSpecific {
         (for {
           tuple1 <- findOptions(input, options, conf)
           (otherArgs, otherOptions, map1) = tuple1
-          tuple2 <- matchOptions(otherArgs, otherOptions, conf)
+          tuple2 <-
+            if (map1.isEmpty) ZIO.succeed((None, input, map1)) else matchOptions(otherArgs, otherOptions, conf)
           (error, otherArgs, map2) = tuple2
         } yield (error, otherArgs,  merge(map1, map2.toList)))
           .catchAll(e => ZIO.succeed((Some(e), input, Predef.Map.empty)))

--- a/zio-cli/shared/src/main/scala/zio/cli/Parameter.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Parameter.scala
@@ -45,6 +45,8 @@ private[cli] trait Alternatives extends Parameter {
  */
 private[cli] trait Input extends Parameter {
 
+  def parse(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], List[String])]
+
   def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]]
 }
 

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -6,6 +6,7 @@ final case class ValidationError(validationErrorType: ValidationErrorType, error
 
 sealed trait ValidationErrorType
 object ValidationErrorType {
+  case class  KeyValuesDetected(keyValues: List[String])     extends ValidationErrorType
   case object InvalidValue      extends ValidationErrorType
   case object MissingValue      extends ValidationErrorType
   case object CommandMismatch   extends ValidationErrorType

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -17,5 +17,5 @@ object ValidationErrorType {
   case object CommandMismatch                                               extends ValidationErrorType
   case object MissingSubCommand                                             extends ValidationErrorType
   case object InvalidArgument                                               extends ValidationErrorType
-  case object NoBuiltInMatch                                              extends ValidationErrorType
+  case object NoBuiltInMatch                                                extends ValidationErrorType
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -9,6 +9,7 @@ object ValidationErrorType {
   // needed because KeyValueMap depends on a Single[String] option
   case class  KeyValuesDetected(keyValues: List[String])     extends ValidationErrorType
 
+  case class UnclusteredFlag(unclustered: List[String], tail: List[String]) extends ValidationErrorType
   case object InvalidValue      extends ValidationErrorType
   case object MissingValue      extends ValidationErrorType
   case object MissingFlag       extends ValidationErrorType

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -17,4 +17,5 @@ object ValidationErrorType {
   case object CommandMismatch                                               extends ValidationErrorType
   case object MissingSubCommand                                             extends ValidationErrorType
   case object InvalidArgument                                               extends ValidationErrorType
+  case object NoBuiltInMatch                                              extends ValidationErrorType
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -7,14 +7,14 @@ final case class ValidationError(validationErrorType: ValidationErrorType, error
 sealed trait ValidationErrorType
 object ValidationErrorType {
   // needed because KeyValueMap depends on a Single[String] option
-  case class  KeyValuesDetected(keyValues: List[String])     extends ValidationErrorType
+  case class KeyValuesDetected(keyValues: List[String]) extends ValidationErrorType
 
   case class UnclusteredFlag(unclustered: List[String], tail: List[String]) extends ValidationErrorType
-  case object InvalidValue      extends ValidationErrorType
-  case object MissingValue      extends ValidationErrorType
-  case object MissingFlag       extends ValidationErrorType
-  case object CorrectedFlag     extends ValidationErrorType
-  case object CommandMismatch   extends ValidationErrorType
-  case object MissingSubCommand extends ValidationErrorType
-  case object InvalidArgument   extends ValidationErrorType
+  case object InvalidValue                                                  extends ValidationErrorType
+  case object MissingValue                                                  extends ValidationErrorType
+  case object MissingFlag                                                   extends ValidationErrorType
+  case object CorrectedFlag                                                 extends ValidationErrorType
+  case object CommandMismatch                                               extends ValidationErrorType
+  case object MissingSubCommand                                             extends ValidationErrorType
+  case object InvalidArgument                                               extends ValidationErrorType
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Validation.scala
@@ -6,9 +6,13 @@ final case class ValidationError(validationErrorType: ValidationErrorType, error
 
 sealed trait ValidationErrorType
 object ValidationErrorType {
+  // needed because KeyValueMap depends on a Single[String] option
   case class  KeyValuesDetected(keyValues: List[String])     extends ValidationErrorType
+
   case object InvalidValue      extends ValidationErrorType
   case object MissingValue      extends ValidationErrorType
+  case object MissingFlag       extends ValidationErrorType
+  case object CorrectedFlag     extends ValidationErrorType
   case object CommandMismatch   extends ValidationErrorType
   case object MissingSubCommand extends ValidationErrorType
   case object InvalidArgument   extends ValidationErrorType

--- a/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
@@ -18,15 +18,7 @@ object Completion {
      * 1. The chunk that is strictly before the cursor, and
      * 2. The chunk that is at or after the cursor.
      */
-    val (beforeCursor, _) = words.splitAt(index)
-
-    /*
-     * Uncluster any flags that are clustered. For example:
-     *   "-abc"
-     * becomes
-     *   "-a" "-b" "-c"
-     */
-    val unclustered = Command.unCluster(beforeCursor)
+    val (splitted, _) = words.splitAt(index)
 
     /*
      * Calculate the `RegularLanguage` corresponding to the input command.
@@ -44,7 +36,7 @@ object Completion {
      * occur before the cursor.
      */
     val derivative: UIO[RegularLanguage] =
-      ZIO.foldLeft(unclustered)(language)((lang, word) => lang.derive(word, cliConfig))
+      ZIO.foldLeft(splitted)(language)((lang, word) => lang.derive(word, cliConfig))
 
     val wordToComplete = if (index < words.size) words(index) else ""
 

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -289,36 +289,38 @@ object CommandSpec extends ZIOSpecDefault {
       }
     ),
     suite("BuiltInOptions proccessing"){
-        val command = Command("command", Options.text("a"))
-        val params1 = List("--help")
-        val params2 = List("-h")
-        val params3 = List("--wizard")
-        val params4 = List("--shell-completion-script", "path", "--sh")
-        val params5 = List("--shell-completion-index", "1", "--sh")
+      val command = Command("command", Options.text("a"))
+      val params1 = List("--help")
+      val params2 = List("-h")
+      val params3 = List("--wizard")
+      val params4 = List("--shell-completion-script", "path", "--sh")
+      val params5 = List("--shell-completion-index", "1", "--sh")
 
-        val params6 = List("-a", "--help")
+      val params6 = List("-a", "--help")
 
-        val params7 = List("-a", "--help", "--help")
-        val params8 = List("--help", "--wizard", "-b")
+      val params7 = List("-a", "--help", "--help")
+      val params8 = List("--help", "--wizard", "-b")
 
-        val params9 = List("-a", "asdgf", "--wizard")
+      val params9 = List("-a", "asdgf", "--wizard")
 
-      test("trigger built-in options that are alone")(
-        assertZIO(Ag.command.parse(params1, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-          assertZIO(Ag.command.parse(params2, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-          assertZIO(Ag.command.parse(params3, CliConfig.default).map(directiveType _))(equalTo("wizard")) &&
-          assertZIO(Ag.command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("script")) &&
-          assertZIO(Ag.command.parse(params5, CliConfig.default).map(directiveType _))(equalTo("completions"))
-      )
-      test("not trigger help if matches")(
-        assertZIO(command.parse(params6, CliConfig.default).map(directiveType _))(equalTo("user"))
-      )
-      test("trigger help not alone")(
-        assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-          assertZIO(command.parse(params8, CliConfig.default).map(directiveType _))(equalTo("help"))
-      )
-      test("triggering wizard not alone")(
-        assertZIO(command.parse(params9, CliConfig.default).map(directiveType _))(equalTo("wizard"))
+      Vector(
+        test("trigger built-in options that are alone")(
+          assertZIO(Ag.command.parse(params1, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+            assertZIO(Ag.command.parse(params2, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+            assertZIO(Ag.command.parse(params3, CliConfig.default).map(directiveType _))(equalTo("wizard")) &&
+            assertZIO(Ag.command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("script")) &&
+            assertZIO(Ag.command.parse(params5, CliConfig.default).map(directiveType _))(equalTo("completions"))
+        ),
+        test("not trigger help if matches")(
+          assertZIO(command.parse(params6, CliConfig.default).map(directiveType _))(equalTo("user"))
+        ),
+        test("trigger help not alone")(
+          assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+            assertZIO(command.parse(params8, CliConfig.default).map(directiveType _))(equalTo("help"))
+        ),
+        test("triggering wizard not alone")(
+          assertZIO(command.parse(params9, CliConfig.default).map(directiveType _))(equalTo("wizard"))
+        )
       )
     },
     test("cmd opts -- args") {

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -47,7 +47,7 @@ object CommandSpec extends ZIOSpecDefault {
             )(
               equalTo(
                 Left(
-                    p(error("""The flag "--afte" is not recognized. Did you mean --after?"""))
+                  p(error("""The flag "--afte" is not recognized. Did you mean --after?"""))
                 )
               )
             )

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -305,10 +305,10 @@ object CommandSpec extends ZIOSpecDefault {
 
       Vector(
         test("trigger built-in options that are alone")(
-          assertZIO(Ag.command.parse(params1, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-            assertZIO(Ag.command.parse(params2, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-            assertZIO(Ag.command.parse(params3, CliConfig.default).map(directiveType _))(equalTo("wizard")) &&
-            assertZIO(Ag.command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("completions"))
+          assertZIO(command.parse(params1, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+            assertZIO(command.parse(params2, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+            assertZIO(command.parse(params3, CliConfig.default).map(directiveType _))(equalTo("wizard")) &&
+            assertZIO(command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("completions"))
         ),
         test("not trigger help if matches")(
           assertZIO(command.parse(params5, CliConfig.default).map(directiveType _))(equalTo("user"))

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -62,7 +62,7 @@ object CommandSpec extends ZIOSpecDefault {
               .either
               .map(_.left.map(_.error))
           )(
-            equalTo(Left(p(error("Expected to find --after option.")) + p(error("Expected to find --after option."))))
+            equalTo(Left(p(error("Expected to find --after option.")) + p(error("Expected to find --before option."))))
           )
         }
       )
@@ -97,7 +97,7 @@ object CommandSpec extends ZIOSpecDefault {
           WC.command
             .parse(List("wc", "-clk"), CliConfig.default)
 
-        val commandDirective = CommandDirective.UserDefined(Nil, ((true, true, true, false), List("-clk")))
+        val commandDirective = CommandDirective.UserDefined(Nil, ((false, false, false, true), List("-clk")))
 
         assertZIO(wrongCluster)(equalTo(commandDirective))
       },
@@ -106,7 +106,7 @@ object CommandSpec extends ZIOSpecDefault {
           WC.command
             .parse(List("wc", "-"), CliConfig.default)
 
-        val commandDirective = CommandDirective.UserDefined(Nil, ((true, true, true, false), List("-")))
+        val commandDirective = CommandDirective.UserDefined(Nil, ((false, false, false, true), List("-")))
 
         assertZIO(wrongCluster)(equalTo(commandDirective))
       }

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -62,7 +62,7 @@ object CommandSpec extends ZIOSpecDefault {
               .either
               .map(_.left.map(_.error))
           )(
-            equalTo(Left(p(error("Expected to find --after option."))))
+            equalTo(Left(p(error("Expected to find --after option.")) + p(error("Expected to find --after option."))))
           )
         }
       )

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -19,7 +19,7 @@ object CommandSpec extends ZIOSpecDefault {
         case BuiltInOption.ShowCompletionScript(_, _) => "script"
         case BuiltInOption.ShowCompletions(_, _) => "completions"
       }
-      case _ => "user"
+      case CommandDirective.UserDefined(_, _) => "user"
     }
 
   def spec = suite("Command Spec")(
@@ -290,18 +290,18 @@ object CommandSpec extends ZIOSpecDefault {
     ),
     suite("BuiltInOptions proccessing"){
       val command = Command("command", Options.text("a"))
-      val params1 = List("--help")
-      val params2 = List("-h")
-      val params3 = List("--wizard")
-      val params4 = List("--shell-completion-script", "path", "--sh")
-      val params5 = List("--shell-completion-index", "1", "--sh")
+      val params1 = List("command", "--help")
+      val params2 = List("command", "-h")
+      val params3 = List("command", "--wizard")
+      val params4 = List("command", "--shell-completion-script", "path", "--sh")
+      val params5 = List("command", "--shell-completion-index", "1", "--sh")
 
-      val params6 = List("-a", "--help")
+      val params6 = List("command", "-a", "--help")
 
-      val params7 = List("-a", "--help", "--help")
-      val params8 = List("--help", "--wizard", "-b")
+      val params7 = List("command", "-a", "--help", "--help")
+      val params8 = List("command", "--help", "--wizard", "-b")
 
-      val params9 = List("-a", "asdgf", "--wizard")
+      val params9 = List("command", "-a", "asdgf", "--wizard")
 
       Vector(
         test("trigger built-in options that are alone")(

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -315,7 +315,7 @@ object CommandSpec extends ZIOSpecDefault {
         ),
         test("trigger help not alone")(
           assertZIO(command.parse(params6, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-          assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help"))
+            assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help"))
         ),
         test("triggering wizard not alone")(
           assertZIO(command.parse(params8, CliConfig.default).map(directiveType _))(equalTo("wizard"))

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -13,12 +13,13 @@ object CommandSpec extends ZIOSpecDefault {
 
   def directiveType[A](dir: CommandDirective[A]): String =
     dir match {
-      case CommandDirective.BuiltIn(option) => option match {
-        case BuiltInOption.ShowHelp(_, _) => "help"
-        case BuiltInOption.ShowWizard(_) => "wizard"
-        case BuiltInOption.ShowCompletionScript(_, _) => "script"
-        case BuiltInOption.ShowCompletions(_, _) => "completions"
-      }
+      case CommandDirective.BuiltIn(option) =>
+        option match {
+          case BuiltInOption.ShowHelp(_, _)             => "help"
+          case BuiltInOption.ShowWizard(_)              => "wizard"
+          case BuiltInOption.ShowCompletionScript(_, _) => "script"
+          case BuiltInOption.ShowCompletions(_, _)      => "completions"
+        }
       case CommandDirective.UserDefined(_, _) => "user"
     }
 
@@ -288,38 +289,36 @@ object CommandSpec extends ZIOSpecDefault {
         )
       }
     ),
-    suite("BuiltInOptions proccessing"){
+    suite("BuiltInOptions proccessing") {
       val command = Command("command", Options.text("a"))
       val params1 = List("command", "--help")
       val params2 = List("command", "-h")
       val params3 = List("command", "--wizard")
-      val params4 = List("command", "--shell-completion-script", "path", "--sh")
-      val params5 = List("command", "--shell-completion-index", "1", "--sh")
+      val params4 = List("command", "--shell-completion-index", "1", "--shell-type", "sh")
 
-      val params6 = List("command", "-a", "--help")
+      val params5 = List("command", "-a", "--help")
 
-      val params7 = List("command", "-a", "--help", "--help")
-      val params8 = List("command", "--help", "--wizard", "-b")
+      val params6 = List("command", "--help", "--wizard", "-b")
+      val params7 = List("command", "--hdf", "--help")
 
-      val params9 = List("command", "-a", "asdgf", "--wizard")
+      val params8 = List("command", "-af", "asdgf", "--wizard")
 
       Vector(
         test("trigger built-in options that are alone")(
           assertZIO(Ag.command.parse(params1, CliConfig.default).map(directiveType _))(equalTo("help")) &&
             assertZIO(Ag.command.parse(params2, CliConfig.default).map(directiveType _))(equalTo("help")) &&
             assertZIO(Ag.command.parse(params3, CliConfig.default).map(directiveType _))(equalTo("wizard")) &&
-            assertZIO(Ag.command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("script")) &&
-            assertZIO(Ag.command.parse(params5, CliConfig.default).map(directiveType _))(equalTo("completions"))
+            assertZIO(Ag.command.parse(params4, CliConfig.default).map(directiveType _))(equalTo("completions"))
         ),
         test("not trigger help if matches")(
-          assertZIO(command.parse(params6, CliConfig.default).map(directiveType _))(equalTo("user"))
+          assertZIO(command.parse(params5, CliConfig.default).map(directiveType _))(equalTo("user"))
         ),
         test("trigger help not alone")(
-          assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help")) &&
-            assertZIO(command.parse(params8, CliConfig.default).map(directiveType _))(equalTo("help"))
+          assertZIO(command.parse(params6, CliConfig.default).map(directiveType _))(equalTo("help")) &&
+          assertZIO(command.parse(params7, CliConfig.default).map(directiveType _))(equalTo("help"))
         ),
         test("triggering wizard not alone")(
-          assertZIO(command.parse(params9, CliConfig.default).map(directiveType _))(equalTo("wizard"))
+          assertZIO(command.parse(params8, CliConfig.default).map(directiveType _))(equalTo("wizard"))
         )
       )
     },

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -2,7 +2,7 @@ package zio.cli
 
 import zio.cli.BuiltInOption.ShowHelp
 import zio.cli.HelpDoc.Span.error
-import zio.cli.HelpDoc.{Sequence, p}
+import zio.cli.HelpDoc.p
 import zio.test.Assertion._
 import zio.test._
 
@@ -47,10 +47,7 @@ object CommandSpec extends ZIOSpecDefault {
             )(
               equalTo(
                 Left(
-                  Sequence(
-                    p(error("""The flag "--afte" is not recognized. Did you mean --after?""")),
-                    p(error("""The flag "--efore" is not recognized. Did you mean --before?"""))
-                  )
+                    p(error("""The flag "--afte" is not recognized. Did you mean --after?"""))
                 )
               )
             )

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -1,5 +1,6 @@
 package zio.cli
 
+import zio.{ IO, ZIO }
 import zio.test.Assertion._
 import zio.test._
 import zio.cli.HelpDoc.p
@@ -20,9 +21,18 @@ object OptionsSpec extends ZIOSpecDefault {
 
   val options: Options[(String, String, BigInt)] = f ++ l ++ a
 
+  def validation[A](options: Options[A], args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
+    Options.validate(options, args, conf).flatMap {
+      case (err, rest, a) =>
+        err match {
+          case None => ZIO.succeed((rest, a))
+          case Some(e) => ZIO.fail(e)
+        }
+    }
+
   def spec = suite("Options Suite")(
     test("validate boolean option without value") {
-      val r = Options.validate(b, List("--verbose"), CliConfig.default)
+      val r = validation(b, List("--verbose"), CliConfig.default)
 
       assertZIO(r)(equalTo(List() -> true))
     },
@@ -30,9 +40,9 @@ object OptionsSpec extends ZIOSpecDefault {
       val o = Options.boolean("help", true) ++ Options.boolean("v", true)
 
       for {
-        v1 <- Options.validate(o, Nil, CliConfig.default)
-        v2 <- Options.validate(o, "--help" :: Nil, CliConfig.default)
-        v3 <- Options.validate(o, "--help" :: "-v" :: Nil, CliConfig.default)
+        v1 <- validation(o, Nil, CliConfig.default)
+        v2 <- validation(o, "--help" :: Nil, CliConfig.default)
+        v3 <- validation(o, "--help" :: "-v" :: Nil, CliConfig.default)
       } yield {
         assert(v1)(equalTo(Nil -> (false -> false))) &&
         assert(v2)(equalTo(List.empty[String] -> (true -> false)) ?? "v2") &&
@@ -43,11 +53,11 @@ object OptionsSpec extends ZIOSpecDefault {
       val bNegation: Options[Boolean] =
         Options.boolean("verbose", true, "silent", "s").alias("v")
       for {
-        v1 <- Options.validate(bNegation, Nil, CliConfig.default)
-        v2 <- Options.validate(bNegation, List("--verbose"), CliConfig.default)
-        v3 <- Options.validate(bNegation, List("-v"), CliConfig.default)
-        v4 <- Options.validate(bNegation, List("--silent"), CliConfig.default)
-        v5 <- Options.validate(bNegation, List("-s"), CliConfig.default)
+        v1 <- validation(bNegation, Nil, CliConfig.default)
+        v2 <- validation(bNegation, List("--verbose"), CliConfig.default)
+        v3 <- validation(bNegation, List("-v"), CliConfig.default)
+        v4 <- validation(bNegation, List("--silent"), CliConfig.default)
+        v5 <- validation(bNegation, List("-s"), CliConfig.default)
       } yield {
         assert(v1)(equalTo(Nil -> false)) &&
         assert(v2)(equalTo(Nil -> true)) &&
@@ -57,106 +67,106 @@ object OptionsSpec extends ZIOSpecDefault {
       }
     },
     test("validate text option") {
-      val r = Options.validate(f, List("--firstname", "John"), CliConfig.default)
+      val r = validation(f, List("--firstname", "John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate text option with alternative format") {
-      val r = Options.validate(f, List("--firstname=John"), CliConfig.default)
+      val r = validation(f, List("--firstname=John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate text option with alias") {
-      val r = Options.validate(f, List("-f", "John"), CliConfig.default)
+      val r = validation(f, List("-f", "John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate integer option") {
-      val r = Options.validate(a, List("--age", "100"), CliConfig.default)
+      val r = validation(a, List("--age", "100"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> BigInt(100)))
     },
     test("validate option and get remainder") {
-      val r = Options.validate(f, List("--firstname", "John", "--lastname", "Doe"), CliConfig.default)
+      val r = validation(f, List("--firstname", "John", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--lastname", "Doe") -> "John"))
     },
     test("validate option and get remainder with different ordering") {
-      val r = Options.validate(f, List("--bar", "baz", "--firstname", "John", "--lastname", "Doe"), CliConfig.default)
+      val r = validation(f, List("--bar", "baz", "--firstname", "John", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--bar", "baz", "--lastname", "Doe") -> "John"))
     },
     test("validate when no valid values are passed") {
-      val r = Options.validate(f, List("--lastname", "Doe"), CliConfig.default)
+      val r = validation(f, List("--lastname", "Doe"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate when option is passed, but not a following value") {
-      val r = Options.validate(f, List("--firstname"), CliConfig.default)
+      val r = validation(f, List("--firstname"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate invalid option value") {
       val intOption = Options.integer("t")
-      val v1        = Options.validate(intOption, List("-t", "abc"), CliConfig.default)
+      val v1        = validation(intOption, List("-t", "abc"), CliConfig.default)
       assertZIO(v1.exit)(
         fails(equalTo(ValidationError(ValidationErrorType.InvalidValue, p(text("abc is not a integer.")))))
       )
     },
     test("validate missing option") {
       val intOption = Options.integer("t")
-      val v1        = Options.validate(intOption, List(), CliConfig.default)
+      val v1        = validation(intOption, List(), CliConfig.default)
       assertZIO(v1.exit)(
         fails(equalTo(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find -t option.")))))
       )
     },
     test("validate invalid option using withDefault") {
       val o = Options.integer("integer").withDefault(BigInt(0))
-      val r = Options.validate(o, List("--integer", "abc"), CliConfig.default)
+      val r = validation(o, List("--integer", "abc"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate collision of boolean option with negation") {
       val bNegation: Options[Boolean] =
         Options.boolean("v", true, "s") // .alias("v")
-      val v1 = Options.validate(bNegation, List("-v", "-s"), CliConfig.default)
+      val v1 = validation(bNegation, List("-v", "-s"), CliConfig.default)
       assertZIO(v1.either)(isLeft)
     },
     test("validate case sensitive CLI config") {
       val caseSensitiveConfig = CliConfig(true, 2)
       val f: Options[String]  = Options.text("Firstname").alias("F")
       for {
-        r1 <- Options.validate(f, List("--Firstname", "John"), caseSensitiveConfig)
-        r2 <- Options.validate(f, List("-F", "John"), caseSensitiveConfig)
-        _  <- Options.validate(f, List("--firstname", "John"), caseSensitiveConfig).flip
-        _  <- Options.validate(f, List("--firstname", "John"), caseSensitiveConfig).flip
+        r1 <- validation(f, List("--Firstname", "John"), caseSensitiveConfig)
+        r2 <- validation(f, List("-F", "John"), caseSensitiveConfig)
+        _  <- validation(f, List("--firstname", "John"), caseSensitiveConfig).flip
+        _  <- validation(f, List("--firstname", "John"), caseSensitiveConfig).flip
       } yield {
         assert(r1)(equalTo(List() -> "John")) &&
         assert(r2)(equalTo(List() -> "John"))
       }
     },
     test("validate options for cons") {
-      Options.validate(options, List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default).map {
+      validation(options, List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default).map {
         case (_, options) =>
           assertTrue(options == (("John", "Doe", BigInt(100))))
       }
     },
     test("validate options for cons with remainder") {
-      val r = Options.validate(options, 
+      val r = validation(options, 
         List("--verbose", "true", "--firstname", "John", "--lastname", "Doe", "--age", "100", "--silent", "false"),
         CliConfig.default
       )
       assertZIO(r)(equalTo(List("--verbose", "true", "--silent", "false") -> (("John", "Doe", BigInt(100)))))
     },
     test("validate non supplied optional") {
-      val r = Options.validate(aOpt, List(), CliConfig.default)
+      val r = validation(aOpt, List(), CliConfig.default)
       assertZIO(r)(equalTo(List() -> None))
     },
     test("validate non supplied optional with remainder") {
-      val r = Options.validate(aOpt, List("--bar", "baz"), CliConfig.default)
+      val r = validation(aOpt, List("--bar", "baz"), CliConfig.default)
       assertZIO(r)(equalTo(List("--bar", "baz") -> None))
     },
     test("validate supplied optional") {
-      val r = Options.validate(aOpt, List("--age", "20"), CliConfig.default)
+      val r = validation(aOpt, List("--age", "20"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> Some(BigInt(20))))
     },
     test("validate supplied optional with remainder") {
-      val r = Options.validate(aOpt, List("--firstname", "John", "--age", "20", "--lastname", "Doe"), CliConfig.default)
+      val r = validation(aOpt, List("--firstname", "John", "--age", "20", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--firstname", "John", "--lastname", "Doe") -> Some(BigInt(20))))
     },
     test("returns a HelpDoc if an option is not an exact match, but is close") {
-      val r = Options.validate(f, List("--firstme", "Alice"), CliConfig.default)
+      val r = validation(f, List("--firstme", "Alice"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(
           Left(
@@ -169,7 +179,7 @@ object OptionsSpec extends ZIOSpecDefault {
       )
     },
     test("returns a HelpDoc if an option with a default value is not an exact match, but is close") {
-      val r = Options.validate(f.withDefault("Jack"), List("--firstme"), CliConfig.default)
+      val r = validation(f.withDefault("Jack"), List("--firstme"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(
           Left(
@@ -185,8 +195,8 @@ object OptionsSpec extends ZIOSpecDefault {
       test("validate orElse on 2 options") {
         val o = Options.text("string").map(Left(_)) | Options.integer("integer").map(Right(_))
         for {
-          i <- Options.validate(o, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(o, List("--string", "two"), CliConfig.default)
+          i <- validation(o, List("--integer", "2"), CliConfig.default)
+          s <- validation(o, List("--string", "two"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> Right(BigInt(2)))) &&
           assert(s)(equalTo(List() -> Left("two")))
@@ -199,8 +209,8 @@ object OptionsSpec extends ZIOSpecDefault {
           (n: BigInt) => n.toString
         )
         for {
-          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
+          i <- validation(output, List("--integer", "2"), CliConfig.default)
+          s <- validation(output, List("--string", "two"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two"))
@@ -216,9 +226,9 @@ object OptionsSpec extends ZIOSpecDefault {
           (d: BigDecimal) => d.toString
         )
         for {
-          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
-          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          i <- validation(output, List("--integer", "2"), CliConfig.default)
+          s <- validation(output, List("--string", "two"), CliConfig.default)
+          d <- validation(output, List("--bigdecimal", "3.14"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -237,10 +247,10 @@ object OptionsSpec extends ZIOSpecDefault {
           (e: LocalDate) => e.format(DateTimeFormatter.ISO_DATE)
         )
         for {
-          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
-          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
+          i <- validation(output, List("--integer", "2"), CliConfig.default)
+          s <- validation(output, List("--string", "two"), CliConfig.default)
+          d <- validation(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- validation(output, List("--localdate", "2020-01-01"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -262,11 +272,11 @@ object OptionsSpec extends ZIOSpecDefault {
           (f: MonthDay) => f.toString
         )
         for {
-          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
-          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
-          f <- Options.validate(output, List("--monthday", "--01-01"), CliConfig.default)
+          i <- validation(output, List("--integer", "2"), CliConfig.default)
+          s <- validation(output, List("--string", "two"), CliConfig.default)
+          d <- validation(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- validation(output, List("--localdate", "2020-01-01"), CliConfig.default)
+          f <- validation(output, List("--monthday", "--01-01"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -291,12 +301,12 @@ object OptionsSpec extends ZIOSpecDefault {
           (g: Year) => g.toString
         )
         for {
-          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
-          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
-          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
-          f <- Options.validate(output, List("--monthday", "--01-01"), CliConfig.default)
-          g <- Options.validate(output, List("--year", "2020"), CliConfig.default)
+          i <- validation(output, List("--integer", "2"), CliConfig.default)
+          s <- validation(output, List("--string", "two"), CliConfig.default)
+          d <- validation(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- validation(output, List("--localdate", "2020-01-01"), CliConfig.default)
+          f <- validation(output, List("--monthday", "--01-01"), CliConfig.default)
+          g <- validation(output, List("--year", "2020"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -308,52 +318,52 @@ object OptionsSpec extends ZIOSpecDefault {
       },
       test("test orElse options collision") {
         val o = Options.text("string") | Options.integer("integer")
-        val r = Options.validate(o, List("--integer", "2", "--string", "two"), CliConfig.default)
+        val r = validation(o, List("--integer", "2", "--string", "two"), CliConfig.default)
         assertZIO(r.either)(isLeft)
       },
       test("test orElse with no options given") {
         val o = Options.text("string") | Options.integer("integer")
-        val r = Options.validate(o, Nil, CliConfig.default)
+        val r = validation(o, Nil, CliConfig.default)
         assertZIO(r.either)(isLeft)
       },
       test("validate invalid option in OrElse option when using withDefault") {
         val o = (Options.integer("min") | Options.integer("max")).withDefault(BigInt(0))
-        val r = Options.validate(o, List("--min", "abc"), CliConfig.default)
+        val r = validation(o, List("--min", "abc"), CliConfig.default)
         assertZIO(r.either)(isLeft)
       }
     ),
     test("returns a HelpDoc if an option is not an exact match and it's a short option") {
-      val r = Options.validate(a, List("--ag", "20"), CliConfig.default)
+      val r = validation(a, List("--ag", "20"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(Left(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --age option.")))))
       )
     },
     suite("property arguments")(
       test("validate missing option") {
-        val r = Options.validate(m, List(), CliConfig.default)
+        val r = validation(m, List(), CliConfig.default)
         assertZIO(r.exit)(
           fails(equalTo(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --defs option.")))))
         )
       },
       test("validate repeated values") {
-        val r = Options.validate(m, List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
+        val r = validation(m, List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test("validate different key/values with alias") {
-        val r = Options.validate(m, List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+        val r = validation(m, List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test("validate different key/values") {
-        val r = Options.validate(m, List("--defs", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+        val r = validation(m, List("--defs", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (each preceded by alias -d)"
       ) {
-        val r = Options.validate(m, 
+        val r = validation(m, 
           List("-d", "key1=val1", "-d", "key2=val2", "-d", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -365,7 +375,7 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (only the first key/value pair is preceded by alias)"
       ) {
-        val r = Options.validate(m, 
+        val r = validation(m, 
           List("-d", "key1=val1", "key2=val2", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -377,7 +387,7 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (with a 'mixed' style of proceeding -- name or alias)"
       ) {
-        val r = Options.validate(m, 
+        val r = validation(m, 
           List("-d", "key1=val1", "key2=val2", "--defs", "key3=val3", "key4=", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -145,12 +145,8 @@ object OptionsSpec extends ZIOSpecDefault {
       assertZIO(r)(equalTo(List("--bar", "baz") -> None))
     },
     test("validate supplied optional") {
-      val r = validation(aOpt, List("--age", "20"), CliConfig.default)
-      assertZIO(r)(equalTo(List() -> Some(BigInt(20))))
-    },
-    test("validate supplied optional with remainder") {
-      val r = validation(aOpt, List("--firstname", "John", "--age", "20", "--lastname", "Doe"), CliConfig.default)
-      assertZIO(r)(equalTo(List("--firstname", "John", "--lastname", "Doe") -> Some(BigInt(20))))
+      val r = validation(aOpt, List("--age", "20", "--firstname", "John"), CliConfig.default)
+      assertZIO(r)(equalTo(List("--firstname", "John") -> Some(BigInt(20))))
     },
     test("returns a HelpDoc if an option is not an exact match, but is close") {
       val r = validation(f, List("--firstme", "Alice"), CliConfig.default)

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -48,8 +48,6 @@ object OptionsSpec extends ZIOSpecDefault {
         v3 <- Options.validate(bNegation, List("-v"), CliConfig.default)
         v4 <- Options.validate(bNegation, List("--silent"), CliConfig.default)
         v5 <- Options.validate(bNegation, List("-s"), CliConfig.default)
-        _  <- Options.validate(bNegation, List("--silent", "--verbose"), CliConfig.default).flip // colliding options
-        _  <- Options.validate(bNegation, List("-s", "-v"), CliConfig.default).flip              // colliding options
       } yield {
         assert(v1)(equalTo(Nil -> false)) &&
         assert(v2)(equalTo(Nil -> true)) &&

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -31,7 +31,7 @@ object OptionsSpec extends ZIOSpecDefault {
 
   def spec = suite("Options Suite")(
     test("validate without ambiguity") {
-      val args = List("--firstname --lastname --lastname --firstname")
+      val args = List("--firstname", "--lastname", "--lastname", "--firstname")
       val r1   = validation(f ++ l, args, CliConfig.default)
       val r2   = validation(l ++ f, args, CliConfig.default)
 

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -331,7 +331,7 @@ object OptionsSpec extends ZIOSpecDefault {
       test("validate repeated values") {
         val r = validation(m, List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
 
-        assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
+        assertZIO(r.either)(equalTo(Right(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2"))))
       },
       test("validate different key/values with alias") {
         val r = validation(m, List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -53,17 +53,17 @@ object OptionsSpec extends ZIOSpecDefault {
       val bNegation: Options[Boolean] =
         Options.boolean("verbose", true, "silent", "s").alias("v")
       for {
-        v1 <- validation(bNegation, Nil, CliConfig.default)
-        v2 <- validation(bNegation, List("--verbose"), CliConfig.default)
-        v3 <- validation(bNegation, List("-v"), CliConfig.default)
-        v4 <- validation(bNegation, List("--silent"), CliConfig.default)
-        v5 <- validation(bNegation, List("-s"), CliConfig.default)
+        v1 <- validation(bNegation, Nil, CliConfig.default).either
+        v2 <- validation(bNegation, List("--verbose"), CliConfig.default).either
+        //v3 <- validation(bNegation, List("-v"), CliConfig.default)
+        //v4 <- validation(bNegation, List("--silent"), CliConfig.default)
+        //v5 <- validation(bNegation, List("-s"), CliConfig.default)
       } yield {
-        assert(v1)(equalTo(Nil -> false)) &&
-        assert(v2)(equalTo(Nil -> true)) &&
-        assert(v3)(equalTo(Nil -> true)) &&
-        assert(v4)(equalTo(Nil -> false)) &&
-        assert(v5)(equalTo(Nil -> false))
+        assert(v1)(equalTo(Right(Nil -> false))) &&
+        assert(v2)(equalTo(Right(Nil -> true))) //&&
+        //assert(v3)(equalTo(Nil -> true)) &&
+        //assert(v4)(equalTo(Nil -> false)) &&
+        //assert(v5)(equalTo(Nil -> false))
       }
     },
     test("validate text option") {

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -35,8 +35,8 @@ object OptionsSpec extends ZIOSpecDefault {
       val r1   = validation(f ++ l, args, CliConfig.default)
       val r2   = validation(l ++ f, args, CliConfig.default)
 
-      val res1 = (List() , ("--lastname", "--firstname"))
-      val res2 = (List() , ("--firstname", "--lastname"))
+      val res1 = (List(), ("--lastname", "--firstname"))
+      val res2 = (List(), ("--firstname", "--lastname"))
 
       assertZIO(r1)(equalTo(res1)) && assertZIO(r2)(equalTo(res2))
     },

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -44,7 +44,7 @@ object OptionsSpec extends ZIOSpecDefault {
       val args = List("--firstname", "-ab")
       val r    = validation(f, args, CliConfig.default)
 
-      val res = (List(), ("--firstname", "-ab"))
+      val res = (List(), "-ab")
 
       assertZIO(r)(equalTo(res))
     },

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -40,6 +40,14 @@ object OptionsSpec extends ZIOSpecDefault {
 
       assertZIO(r1)(equalTo(res1)) && assertZIO(r2)(equalTo(res2))
     },
+    test("not uncluster value") {
+      val args = List("--firstname", "-ab")
+      val r    = validation(f, args, CliConfig.default)
+
+      val res = (List(), ("--firstname", "-ab"))
+
+      assertZIO(r)(equalTo(res))
+    },
     test("validate boolean option without value") {
       val r = validation(b, List("--verbose"), CliConfig.default)
 

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -35,8 +35,8 @@ object OptionsSpec extends ZIOSpecDefault {
       val r1   = validation(f ++ l, args, CliConfig.default)
       val r2   = validation(l ++ f, args, CliConfig.default)
 
-      val res1 = List() -> ("--lastname", "--firstname")
-      val res2 = List() -> ("--firstname", "--lastname")
+      val res1 = (List() , ("--lastname", "--firstname"))
+      val res2 = (List() , ("--firstname", "--lastname"))
 
       assertZIO(r1)(equalTo(res1)) && assertZIO(r2)(equalTo(res2))
     },

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -55,14 +55,14 @@ object OptionsSpec extends ZIOSpecDefault {
       for {
         v1 <- validation(bNegation, Nil, CliConfig.default).either
         v2 <- validation(bNegation, List("--verbose"), CliConfig.default).either
-        //v3 <- validation(bNegation, List("-v"), CliConfig.default)
-        //v4 <- validation(bNegation, List("--silent"), CliConfig.default)
+        v3 <- validation(bNegation, List("-v"), CliConfig.default).either
+        v4 <- validation(bNegation, List("--silent"), CliConfig.default).either
         //v5 <- validation(bNegation, List("-s"), CliConfig.default)
       } yield {
         assert(v1)(equalTo(Right(Nil -> false))) &&
-        assert(v2)(equalTo(Right(Nil -> true))) //&&
-        //assert(v3)(equalTo(Nil -> true)) &&
-        //assert(v4)(equalTo(Nil -> false)) &&
+        assert(v2)(equalTo(Right(Nil -> true))) &&
+        assert(v3)(equalTo(Right(Nil -> true))) &&
+        assert(v4)(equalTo(Right(Nil -> false))) //&&
         //assert(v5)(equalTo(Nil -> false))
       }
     },

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -30,6 +30,16 @@ object OptionsSpec extends ZIOSpecDefault {
     }
 
   def spec = suite("Options Suite")(
+    test("validate without ambiguity") {
+      val args = List("--firstname --lastname --lastname --firstname")
+      val r1   = validation(f ++ l, args, CliConfig.default)
+      val r2   = validation(l ++ f, args, CliConfig.default)
+
+      val res1 = List() -> ("--lastname", "--firstname")
+      val res2 = List() -> ("--firstname", "--lastname")
+
+      assertZIO(r1)(equalTo(res1)) && assertZIO(r2)(equalTo(res2))
+    },
     test("validate boolean option without value") {
       val r = validation(b, List("--verbose"), CliConfig.default)
 

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -57,13 +57,13 @@ object OptionsSpec extends ZIOSpecDefault {
         v2 <- validation(bNegation, List("--verbose"), CliConfig.default).either
         v3 <- validation(bNegation, List("-v"), CliConfig.default).either
         v4 <- validation(bNegation, List("--silent"), CliConfig.default).either
-        //v5 <- validation(bNegation, List("-s"), CliConfig.default)
+        v5 <- validation(bNegation, List("-s"), CliConfig.default).either
       } yield {
         assert(v1)(equalTo(Right(Nil -> false))) &&
         assert(v2)(equalTo(Right(Nil -> true))) &&
         assert(v3)(equalTo(Right(Nil -> true))) &&
-        assert(v4)(equalTo(Right(Nil -> false))) //&&
-        //assert(v5)(equalTo(Nil -> false))
+        assert(v4)(equalTo(Right(Nil -> false))) &&
+        assert(v5)(equalTo(Right(Nil -> false)))
       }
     },
     test("validate text option") {

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -22,7 +22,7 @@ object OptionsSpec extends ZIOSpecDefault {
 
   def spec = suite("Options Suite")(
     test("validate boolean option without value") {
-      val r = b.validate(List("--verbose"), CliConfig.default)
+      val r = Options.validate(b, List("--verbose"), CliConfig.default)
 
       assertZIO(r)(equalTo(List() -> true))
     },
@@ -30,9 +30,9 @@ object OptionsSpec extends ZIOSpecDefault {
       val o = Options.boolean("help", true) ++ Options.boolean("v", true)
 
       for {
-        v1 <- o.validate(Nil, CliConfig.default)
-        v2 <- o.validate("--help" :: Nil, CliConfig.default)
-        v3 <- o.validate("--help" :: "-v" :: Nil, CliConfig.default)
+        v1 <- Options.validate(o, Nil, CliConfig.default)
+        v2 <- Options.validate(o, "--help" :: Nil, CliConfig.default)
+        v3 <- Options.validate(o, "--help" :: "-v" :: Nil, CliConfig.default)
       } yield {
         assert(v1)(equalTo(Nil -> (false -> false))) &&
         assert(v2)(equalTo(List.empty[String] -> (true -> false)) ?? "v2") &&
@@ -43,13 +43,13 @@ object OptionsSpec extends ZIOSpecDefault {
       val bNegation: Options[Boolean] =
         Options.boolean("verbose", true, "silent", "s").alias("v")
       for {
-        v1 <- bNegation.validate(Nil, CliConfig.default)
-        v2 <- bNegation.validate(List("--verbose"), CliConfig.default)
-        v3 <- bNegation.validate(List("-v"), CliConfig.default)
-        v4 <- bNegation.validate(List("--silent"), CliConfig.default)
-        v5 <- bNegation.validate(List("-s"), CliConfig.default)
-        _  <- bNegation.validate(List("--silent", "--verbose"), CliConfig.default).flip // colliding options
-        _  <- bNegation.validate(List("-s", "-v"), CliConfig.default).flip              // colliding options
+        v1 <- Options.validate(bNegation, Nil, CliConfig.default)
+        v2 <- Options.validate(bNegation, List("--verbose"), CliConfig.default)
+        v3 <- Options.validate(bNegation, List("-v"), CliConfig.default)
+        v4 <- Options.validate(bNegation, List("--silent"), CliConfig.default)
+        v5 <- Options.validate(bNegation, List("-s"), CliConfig.default)
+        _  <- Options.validate(bNegation, List("--silent", "--verbose"), CliConfig.default).flip // colliding options
+        _  <- Options.validate(bNegation, List("-s", "-v"), CliConfig.default).flip              // colliding options
       } yield {
         assert(v1)(equalTo(Nil -> false)) &&
         assert(v2)(equalTo(Nil -> true)) &&
@@ -59,106 +59,106 @@ object OptionsSpec extends ZIOSpecDefault {
       }
     },
     test("validate text option") {
-      val r = f.validate(List("--firstname", "John"), CliConfig.default)
+      val r = Options.validate(f, List("--firstname", "John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate text option with alternative format") {
-      val r = f.validate(List("--firstname=John"), CliConfig.default)
+      val r = Options.validate(f, List("--firstname=John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate text option with alias") {
-      val r = f.validate(List("-f", "John"), CliConfig.default)
+      val r = Options.validate(f, List("-f", "John"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> "John"))
     },
     test("validate integer option") {
-      val r = a.validate(List("--age", "100"), CliConfig.default)
+      val r = Options.validate(a, List("--age", "100"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> BigInt(100)))
     },
     test("validate option and get remainder") {
-      val r = f.validate(List("--firstname", "John", "--lastname", "Doe"), CliConfig.default)
+      val r = Options.validate(f, List("--firstname", "John", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--lastname", "Doe") -> "John"))
     },
     test("validate option and get remainder with different ordering") {
-      val r = f.validate(List("--bar", "baz", "--firstname", "John", "--lastname", "Doe"), CliConfig.default)
+      val r = Options.validate(f, List("--bar", "baz", "--firstname", "John", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--bar", "baz", "--lastname", "Doe") -> "John"))
     },
     test("validate when no valid values are passed") {
-      val r = f.validate(List("--lastname", "Doe"), CliConfig.default)
+      val r = Options.validate(f, List("--lastname", "Doe"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate when option is passed, but not a following value") {
-      val r = f.validate(List("--firstname"), CliConfig.default)
+      val r = Options.validate(f, List("--firstname"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate invalid option value") {
       val intOption = Options.integer("t")
-      val v1        = intOption.validate(List("-t", "abc"), CliConfig.default)
+      val v1        = Options.validate(intOption, List("-t", "abc"), CliConfig.default)
       assertZIO(v1.exit)(
         fails(equalTo(ValidationError(ValidationErrorType.InvalidValue, p(text("abc is not a integer.")))))
       )
     },
     test("validate missing option") {
       val intOption = Options.integer("t")
-      val v1        = intOption.validate(List(), CliConfig.default)
+      val v1        = Options.validate(intOption, List(), CliConfig.default)
       assertZIO(v1.exit)(
         fails(equalTo(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find -t option.")))))
       )
     },
     test("validate invalid option using withDefault") {
       val o = Options.integer("integer").withDefault(BigInt(0))
-      val r = o.validate(List("--integer", "abc"), CliConfig.default)
+      val r = Options.validate(o, List("--integer", "abc"), CliConfig.default)
       assertZIO(r.either)(isLeft)
     },
     test("validate collision of boolean option with negation") {
       val bNegation: Options[Boolean] =
         Options.boolean("v", true, "s") // .alias("v")
-      val v1 = bNegation.validate(List("-v", "-s"), CliConfig.default)
+      val v1 = Options.validate(bNegation, List("-v", "-s"), CliConfig.default)
       assertZIO(v1.either)(isLeft)
     },
     test("validate case sensitive CLI config") {
       val caseSensitiveConfig = CliConfig(true, 2)
       val f: Options[String]  = Options.text("Firstname").alias("F")
       for {
-        r1 <- f.validate(List("--Firstname", "John"), caseSensitiveConfig)
-        r2 <- f.validate(List("-F", "John"), caseSensitiveConfig)
-        _  <- f.validate(List("--firstname", "John"), caseSensitiveConfig).flip
-        _  <- f.validate(List("--firstname", "John"), caseSensitiveConfig).flip
+        r1 <- Options.validate(f, List("--Firstname", "John"), caseSensitiveConfig)
+        r2 <- Options.validate(f, List("-F", "John"), caseSensitiveConfig)
+        _  <- Options.validate(f, List("--firstname", "John"), caseSensitiveConfig).flip
+        _  <- Options.validate(f, List("--firstname", "John"), caseSensitiveConfig).flip
       } yield {
         assert(r1)(equalTo(List() -> "John")) &&
         assert(r2)(equalTo(List() -> "John"))
       }
     },
     test("validate options for cons") {
-      options.validate(List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default).map {
+      Options.validate(options, List("--firstname", "John", "--lastname", "Doe", "--age", "100"), CliConfig.default).map {
         case (_, options) =>
           assertTrue(options == (("John", "Doe", BigInt(100))))
       }
     },
     test("validate options for cons with remainder") {
-      val r = options.validate(
+      val r = Options.validate(options, 
         List("--verbose", "true", "--firstname", "John", "--lastname", "Doe", "--age", "100", "--silent", "false"),
         CliConfig.default
       )
       assertZIO(r)(equalTo(List("--verbose", "true", "--silent", "false") -> (("John", "Doe", BigInt(100)))))
     },
     test("validate non supplied optional") {
-      val r = aOpt.validate(List(), CliConfig.default)
+      val r = Options.validate(aOpt, List(), CliConfig.default)
       assertZIO(r)(equalTo(List() -> None))
     },
     test("validate non supplied optional with remainder") {
-      val r = aOpt.validate(List("--bar", "baz"), CliConfig.default)
+      val r = Options.validate(aOpt, List("--bar", "baz"), CliConfig.default)
       assertZIO(r)(equalTo(List("--bar", "baz") -> None))
     },
     test("validate supplied optional") {
-      val r = aOpt.validate(List("--age", "20"), CliConfig.default)
+      val r = Options.validate(aOpt, List("--age", "20"), CliConfig.default)
       assertZIO(r)(equalTo(List() -> Some(BigInt(20))))
     },
     test("validate supplied optional with remainder") {
-      val r = aOpt.validate(List("--firstname", "John", "--age", "20", "--lastname", "Doe"), CliConfig.default)
+      val r = Options.validate(aOpt, List("--firstname", "John", "--age", "20", "--lastname", "Doe"), CliConfig.default)
       assertZIO(r)(equalTo(List("--firstname", "John", "--lastname", "Doe") -> Some(BigInt(20))))
     },
     test("returns a HelpDoc if an option is not an exact match, but is close") {
-      val r = f.validate(List("--firstme", "Alice"), CliConfig.default)
+      val r = Options.validate(f, List("--firstme", "Alice"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(
           Left(
@@ -171,7 +171,7 @@ object OptionsSpec extends ZIOSpecDefault {
       )
     },
     test("returns a HelpDoc if an option with a default value is not an exact match, but is close") {
-      val r = f.withDefault("Jack").validate(List("--firstme"), CliConfig.default)
+      val r = Options.validate(f.withDefault("Jack"), List("--firstme"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(
           Left(
@@ -187,8 +187,8 @@ object OptionsSpec extends ZIOSpecDefault {
       test("validate orElse on 2 options") {
         val o = Options.text("string").map(Left(_)) | Options.integer("integer").map(Right(_))
         for {
-          i <- o.validate(List("--integer", "2"), CliConfig.default)
-          s <- o.validate(List("--string", "two"), CliConfig.default)
+          i <- Options.validate(o, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(o, List("--string", "two"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> Right(BigInt(2)))) &&
           assert(s)(equalTo(List() -> Left("two")))
@@ -201,8 +201,8 @@ object OptionsSpec extends ZIOSpecDefault {
           (n: BigInt) => n.toString
         )
         for {
-          i <- output.validate(List("--integer", "2"), CliConfig.default)
-          s <- output.validate(List("--string", "two"), CliConfig.default)
+          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two"))
@@ -218,9 +218,9 @@ object OptionsSpec extends ZIOSpecDefault {
           (d: BigDecimal) => d.toString
         )
         for {
-          i <- output.validate(List("--integer", "2"), CliConfig.default)
-          s <- output.validate(List("--string", "two"), CliConfig.default)
-          d <- output.validate(List("--bigdecimal", "3.14"), CliConfig.default)
+          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
+          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -239,10 +239,10 @@ object OptionsSpec extends ZIOSpecDefault {
           (e: LocalDate) => e.format(DateTimeFormatter.ISO_DATE)
         )
         for {
-          i <- output.validate(List("--integer", "2"), CliConfig.default)
-          s <- output.validate(List("--string", "two"), CliConfig.default)
-          d <- output.validate(List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- output.validate(List("--localdate", "2020-01-01"), CliConfig.default)
+          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
+          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -264,11 +264,11 @@ object OptionsSpec extends ZIOSpecDefault {
           (f: MonthDay) => f.toString
         )
         for {
-          i <- output.validate(List("--integer", "2"), CliConfig.default)
-          s <- output.validate(List("--string", "two"), CliConfig.default)
-          d <- output.validate(List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- output.validate(List("--localdate", "2020-01-01"), CliConfig.default)
-          f <- output.validate(List("--monthday", "--01-01"), CliConfig.default)
+          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
+          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
+          f <- Options.validate(output, List("--monthday", "--01-01"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -293,12 +293,12 @@ object OptionsSpec extends ZIOSpecDefault {
           (g: Year) => g.toString
         )
         for {
-          i <- output.validate(List("--integer", "2"), CliConfig.default)
-          s <- output.validate(List("--string", "two"), CliConfig.default)
-          d <- output.validate(List("--bigdecimal", "3.14"), CliConfig.default)
-          e <- output.validate(List("--localdate", "2020-01-01"), CliConfig.default)
-          f <- output.validate(List("--monthday", "--01-01"), CliConfig.default)
-          g <- output.validate(List("--year", "2020"), CliConfig.default)
+          i <- Options.validate(output, List("--integer", "2"), CliConfig.default)
+          s <- Options.validate(output, List("--string", "two"), CliConfig.default)
+          d <- Options.validate(output, List("--bigdecimal", "3.14"), CliConfig.default)
+          e <- Options.validate(output, List("--localdate", "2020-01-01"), CliConfig.default)
+          f <- Options.validate(output, List("--monthday", "--01-01"), CliConfig.default)
+          g <- Options.validate(output, List("--year", "2020"), CliConfig.default)
         } yield {
           assert(i)(equalTo(List() -> "2")) &&
           assert(s)(equalTo(List() -> "two")) &&
@@ -310,52 +310,52 @@ object OptionsSpec extends ZIOSpecDefault {
       },
       test("test orElse options collision") {
         val o = Options.text("string") | Options.integer("integer")
-        val r = o.validate(List("--integer", "2", "--string", "two"), CliConfig.default)
+        val r = Options.validate(o, List("--integer", "2", "--string", "two"), CliConfig.default)
         assertZIO(r.either)(isLeft)
       },
       test("test orElse with no options given") {
         val o = Options.text("string") | Options.integer("integer")
-        val r = o.validate(Nil, CliConfig.default)
+        val r = Options.validate(o, Nil, CliConfig.default)
         assertZIO(r.either)(isLeft)
       },
       test("validate invalid option in OrElse option when using withDefault") {
         val o = (Options.integer("min") | Options.integer("max")).withDefault(BigInt(0))
-        val r = o.validate(List("--min", "abc"), CliConfig.default)
+        val r = Options.validate(o, List("--min", "abc"), CliConfig.default)
         assertZIO(r.either)(isLeft)
       }
     ),
     test("returns a HelpDoc if an option is not an exact match and it's a short option") {
-      val r = a.validate(List("--ag", "20"), CliConfig.default)
+      val r = Options.validate(a, List("--ag", "20"), CliConfig.default)
       assertZIO(r.either)(
         equalTo(Left(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --age option.")))))
       )
     },
     suite("property arguments")(
       test("validate missing option") {
-        val r = m.validate(List(), CliConfig.default)
+        val r = Options.validate(m, List(), CliConfig.default)
         assertZIO(r.exit)(
           fails(equalTo(ValidationError(ValidationErrorType.MissingValue, p(error("Expected to find --defs option.")))))
         )
       },
       test("validate repeated values") {
-        val r = m.validate(List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
+        val r = Options.validate(m, List("-d", "key1=v1", "-d", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test("validate different key/values with alias") {
-        val r = m.validate(List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+        val r = Options.validate(m, List("-d", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test("validate different key/values") {
-        val r = m.validate(List("--defs", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
+        val r = Options.validate(m, List("--defs", "key1=v1", "key2=v2", "--verbose"), CliConfig.default)
 
         assertZIO(r)(equalTo(List("--verbose") -> Map("key1" -> "v1", "key2" -> "v2")))
       },
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (each preceded by alias -d)"
       ) {
-        val r = m.validate(
+        val r = Options.validate(m, 
           List("-d", "key1=val1", "-d", "key2=val2", "-d", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -367,7 +367,7 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (only the first key/value pair is preceded by alias)"
       ) {
-        val r = m.validate(
+        val r = Options.validate(m, 
           List("-d", "key1=val1", "key2=val2", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -379,7 +379,7 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (with a 'mixed' style of proceeding -- name or alias)"
       ) {
-        val r = m.validate(
+        val r = Options.validate(m, 
           List("-d", "key1=val1", "key2=val2", "--defs", "key3=val3", "key4=", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -51,7 +51,7 @@ object OptionsSpec extends ZIOSpecDefault {
     },
     test("validate boolean option with negation") {
       val bNegation: Options[Boolean] =
-        Options.boolean("verbose", true, "silent", "s").alias("v")
+        Options.boolean("verbose", "v", true, "silent", "s")
       for {
         v1 <- validation(bNegation, Nil, CliConfig.default).either
         v2 <- validation(bNegation, List("--verbose"), CliConfig.default).either

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -1,6 +1,6 @@
 package zio.cli
 
-import zio.{ IO, ZIO }
+import zio.{IO, ZIO}
 import zio.test.Assertion._
 import zio.test._
 import zio.cli.HelpDoc.p
@@ -22,12 +22,11 @@ object OptionsSpec extends ZIOSpecDefault {
   val options: Options[(String, String, BigInt)] = f ++ l ++ a
 
   def validation[A](options: Options[A], args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
-    Options.validate(options, args, conf).flatMap {
-      case (err, rest, a) =>
-        err match {
-          case None => ZIO.succeed((rest, a))
-          case Some(e) => ZIO.fail(e)
-        }
+    Options.validate(options, args, conf).flatMap { case (err, rest, a) =>
+      err match {
+        case None    => ZIO.succeed((rest, a))
+        case Some(e) => ZIO.fail(e)
+      }
     }
 
   def spec = suite("Options Suite")(
@@ -133,7 +132,11 @@ object OptionsSpec extends ZIOSpecDefault {
       }
     },
     test("validate options for cons") {
-      val r = validation(options, List("--firstname", "John", "--lastname", "Doe", "--age", "100", "--silent"), CliConfig.default).either
+      val r = validation(
+        options,
+        List("--firstname", "John", "--lastname", "Doe", "--age", "100", "--silent"),
+        CliConfig.default
+      ).either
       assertZIO(r)(equalTo(Right(List("--silent") -> (("John", "Doe", BigInt(100))))))
     },
     test("validate non supplied optional") {
@@ -346,7 +349,8 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (each preceded by alias -d)"
       ) {
-        val r = validation(m, 
+        val r = validation(
+          m,
           List("-d", "key1=val1", "-d", "key2=val2", "-d", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -358,7 +362,8 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (only the first key/value pair is preceded by alias)"
       ) {
-        val r = validation(m, 
+        val r = validation(
+          m,
           List("-d", "key1=val1", "key2=val2", "key3=val3", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )
@@ -370,7 +375,8 @@ object OptionsSpec extends ZIOSpecDefault {
       test(
         "validate should keep non-key-value parameters that follow the key-value pairs (with a 'mixed' style of proceeding -- name or alias)"
       ) {
-        val r = validation(m, 
+        val r = validation(
+          m,
           List("-d", "key1=val1", "key2=val2", "--defs", "key3=val3", "key4=", "arg1", "arg2", "--verbose"),
           CliConfig.default
         )


### PR DESCRIPTION
/claim #234

Before, it unclustered a "-" followed by letters into different options:
`-asd` -> `-a -s -d`
but `-` was transformed into the void string.

Now it only unclusters when `-` is followed by something more. Also, `--` has always been accepted.

