### PR TITLE
withPseudoName for Options

### DIFF
--- a/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/oauth2/OAuth2PlatformSpecific.scala
@@ -26,7 +26,7 @@ private[cli] object OAuth2PlatformSpecific {
       case KeyValueMap(_)                => None
       case Empty                         => None
       case Options.OrElse(left, right)   => findProvider(left).orElse(findProvider(right))
-      case Options.Single(_, _, _, _)    => None
+      case Options.Single(_, _, _, _, _) => None
       case OAuth2Options(provider, _, _) => Some(provider)
       case WithDefault(options, _)       => findProvider(options)
     }

--- a/zio-cli/shared/src/main/scala/zio/cli/Options.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Options.scala
@@ -151,7 +151,7 @@ sealed trait Options[+A] extends Parameter { self =>
     self.asInstanceOf[Options[_]] match {
       case Options.Empty                   => false
       case Options.WithDefault(options, _) => options.isBool
-      case Single(_, _, primType, _)       => primType.isBool
+      case Single(_, _, primType, _, _)    => primType.isBool
       case Options.Map(value, _)           => value.isBool
       case _                               => false
     }
@@ -169,8 +169,8 @@ sealed trait Options[+A] extends Parameter { self =>
 
   final def primitiveType: Option[PrimType[A]] =
     self match {
-      case Single(_, _, primType, _) => Some(primType)
-      case _                         => None
+      case Single(_, _, primType, _, _) => Some(primType)
+      case _                            => None
     }
 
   def synopsis: UsageSynopsis
@@ -181,6 +181,17 @@ sealed trait Options[+A] extends Parameter { self =>
 
   def withDefault[A1 >: A](value: A1): Options[A1] =
     Options.WithDefault(self, value)
+
+  /**
+   * Customizes the name used to print a placeholder value in help strings.
+   *
+   * The default is the type name of the option (for example 'text', 'integer', etc.
+   */
+  def withPseudoName(name: String): Options[A] =
+    modifySingle(new SingleModifier {
+      override def apply[A2](single: Single[A2]): Single[A2] =
+        single.copy(pseudoName = Some(name))
+    })
 
   private[cli] def modifySingle(f: SingleModifier): Options[A]
 
@@ -251,7 +262,8 @@ object Options extends OptionsPlatformSpecific {
     name: String,
     aliases: Vector[String],
     primType: PrimType[A],
-    description: HelpDoc = HelpDoc.Empty
+    description: HelpDoc = HelpDoc.Empty,
+    pseudoName: Option[String] = None
   ) extends Options[A]
       with Input { self =>
 
@@ -262,7 +274,7 @@ object Options extends OptionsPlatformSpecific {
     lazy val synopsis: UsageSynopsis =
       UsageSynopsis.Named(
         self.names,
-        if (!self.primType.isBool) self.primType.choices.orElse(Some(self.primType.typeName)) else None
+        if (!self.primType.isBool) self.primType.choices.orElse(Some(placeholder)) else None
       )
 
     def validate(args: List[String], conf: CliConfig): IO[ValidationError, (List[String], A)] =
@@ -331,6 +343,8 @@ object Options extends OptionsPlatformSpecific {
     override def isValid(input: String, conf: CliConfig): IO[ValidationError, List[String]] = for {
       _ <- validate(List(self.names.head, input), conf)
     } yield List(self.names.head, input)
+
+    private def placeholder: String = "<" + self.pseudoName.getOrElse(self.primType.typeName) + ">"
   }
 
   final case class OrElse[A, B](left: Options[A], right: Options[B]) extends Options[Either[A, B]] with Alternatives {

--- a/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/completion/Completion.scala
@@ -89,9 +89,9 @@ object Completion {
         Epsilon
       case Options.WithDefault(options, _) =>
         toRegularLanguage(options).?
-      case single @ Options.Single(_, _, _: PrimType.Bool, _) =>
+      case single @ Options.Single(_, _, _: PrimType.Bool, _, _) =>
         single.names.foldLeft[RegularLanguage](Empty)((lang, name) => lang | StringToken(name))
-      case single @ Options.Single(_, _, primType, _) =>
+      case single @ Options.Single(_, _, primType, _, _) =>
         val names = single.names.foldLeft[RegularLanguage](Empty)((lang, name) => lang | StringToken(name))
         names ~ PrimTypeToken(primType)
       case Options.OrElse(left, right) =>

--- a/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/OptionsSpec.scala
@@ -395,7 +395,7 @@ object OptionsSpec extends ZIOSpecDefault {
     test("Help describes default value but does not print None as default value") {
       assertTrue(
         aOpt.helpDoc.toPlaintext(color = false).trim ==
-          """--age integer
+          """--age <integer>
             |  An integer.
             |
             |  This setting is optional.
@@ -405,10 +405,30 @@ object OptionsSpec extends ZIOSpecDefault {
     test("Help describes default value if it is not None") {
       assertTrue(
         lOpt.helpDoc.toPlaintext(color = false).trim ==
-          """--lastname text
+          """--lastname <text>
             |  A user-defined piece of text.
             |
             |  This setting is optional. Default: 'xyz'.
+            |""".stripMargin.trim
+      )
+    },
+    test("Can overwrite the placeholder used in the help string") {
+      assertTrue(
+        lOpt
+          .withPseudoName("NAME")
+          .helpDoc
+          .toPlaintext(color = false)
+          .trim ==
+          """--lastname <NAME>
+            |  A user-defined piece of text.
+            |
+            |  This setting is optional. Default: 'xyz'.
+            |""".stripMargin.trim,
+        aOpt.withPseudoName("age").helpDoc.toPlaintext(color = false).trim ==
+          """--age <age>
+            |  An integer.
+            |
+            |  This setting is optional.
             |""".stripMargin.trim
       )
     }

--- a/zio-cli/shared/src/test/scala/zio/cli/WizardSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/WizardSpec.scala
@@ -45,7 +45,7 @@ object WizardSpec extends ZIOSpecDefault {
       case Options.Map(_, _)      => "pipeline"
       case Options.OrElse(_, _)   => "alternatives"
       case KeyValueMap(_)         => "input"
-      case Single(_, _, _, _)     => "input"
+      case Single(_, _, _, _, _)  => "input"
       case WithDefault(_, _)      => "input"
       case OAuth2Options(_, _, _) => "wrap"
     }


### PR DESCRIPTION
Resolves #238 

(the `pseudoName` name is copied from the existing similar field in `Args`)