### PR TITLE
Clearer OrElse synopsis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'master' ]
+    branches: [ 'orElse' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'orElse' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -64,7 +64,10 @@ object CliApp {
 
             val header = p(text(self.name) + text(self.version) + text(" -- ") + self.summary)
 
-            val synopsisHelpDoc = h1("usage") + HelpDoc.p(text("$ ") + synopsis.helpDoc.getSpan)
+            val synopsisHelpDoc = h1("usage") + synopsis.enumerate
+              .map(span => text("$ ") + span)
+              .map(HelpDoc.p)
+              .foldRight(HelpDoc.empty)(_ + _)
 
             // TODO add rendering of built-in options such as help
             printLine((fancyName + header + synopsisHelpDoc + helpDoc + self.footer).toPlaintext(columnWidth = 300))

--- a/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
@@ -10,7 +10,7 @@ sealed trait UsageSynopsis { self =>
 
     def simplify(g: UsageSynopsis): UsageSynopsis =
       g match {
-        case named @ Named(names, acceptedValues) =>
+        case named @ Named(_, _) =>
           if (render(named).head.isEmpty) None else named
         case Optional(None) => None
         case Optional(value) =>
@@ -19,7 +19,7 @@ sealed trait UsageSynopsis { self =>
         case Repeated(value) =>
           val syn = simplify(value)
           if (syn == None) None else Repeated(syn)
-        case seq @ Sequence(left, right) =>
+        case Sequence(left, right) =>
           val leftSyn  = simplify(left)
           val rightSyn = simplify(right)
           if (leftSyn == None) rightSyn else if (rightSyn == None) leftSyn else Sequence(leftSyn, rightSyn)

--- a/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
@@ -26,7 +26,7 @@ sealed trait UsageSynopsis { self =>
         case Alternation(left, right) =>
           val leftSyn  = simplify(left)
           val rightSyn = simplify(right)
-          if (leftSyn == None) rightSyn else if (rightSyn == None) leftSyn else Sequence(leftSyn, rightSyn)
+          if (leftSyn == None) rightSyn else if (rightSyn == None) leftSyn else Alternation(leftSyn, rightSyn)
         case Mixed => Mixed
         case None  => None
 

--- a/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/UsageSynopsis.scala
@@ -5,39 +5,87 @@ import zio.cli.HelpDoc._
 sealed trait UsageSynopsis { self =>
   final def +(that: UsageSynopsis): UsageSynopsis = UsageSynopsis.Sequence(self, that)
 
-  final def helpDoc: HelpDoc = {
+  final def enumerate: List[Span] = {
     import UsageSynopsis._
 
-    def render(g: UsageSynopsis): Span =
+    def simplify(g: UsageSynopsis): UsageSynopsis =
+      g match {
+        case named @ Named(names, acceptedValues) =>
+          if (render(named).head.isEmpty) None else named
+        case Optional(None) => None
+        case Optional(value) =>
+          val syn = simplify(value)
+          if (syn == None) None else Optional(syn)
+        case Repeated(value) =>
+          val syn = simplify(value)
+          if (syn == None) None else Repeated(syn)
+        case seq @ Sequence(left, right) =>
+          val leftSyn  = simplify(left)
+          val rightSyn = simplify(right)
+          if (leftSyn == None) rightSyn else if (rightSyn == None) leftSyn else Sequence(leftSyn, rightSyn)
+        case Alternation(left, right) =>
+          val leftSyn  = simplify(left)
+          val rightSyn = simplify(right)
+          if (leftSyn == None) rightSyn else if (rightSyn == None) leftSyn else Sequence(leftSyn, rightSyn)
+        case Mixed => Mixed
+        case None  => None
+
+      }
+
+    def render(g: UsageSynopsis): List[Span] =
       g match {
         case Named(names, acceptedValues) =>
           val mainSpan =
             Span.text(names.mkString(", ")) + acceptedValues.fold(Span.empty)(c => Span.space + Span.text(c))
-          if (names.length > 1) Span.text("(") + mainSpan + Span.text(")") else mainSpan
+          if (names.length > 1) Span.text("(") + mainSpan + Span.text(")") :: Nil else mainSpan :: Nil
 
         case Optional(value) =>
-          Span.text("[") + render(value) + Span.text("]")
+          render(value).map(synopsis => Span.text("[") + synopsis + Span.text("]"))
 
         case Repeated(value) =>
-          render(value) + Span.text("...")
+          render(value).map(_ + Span.text("..."))
 
         case Sequence(left, right) =>
           val leftSpan  = render(left)
           val rightSpan = render(right)
           val separator = if (!leftSpan.isEmpty && !rightSpan.isEmpty) Span.space else Span.empty
 
-          leftSpan + separator + rightSpan
+          for {
+            l <- leftSpan
+            r <- rightSpan
+          } yield l + separator + r
+
+        case Alternation(left: Repeated, right) =>
+          render(left) ++ render(right)
+
+        case Alternation(left: Sequence, right) =>
+          render(left) ++ render(right)
+
+        case Alternation(left, right: Repeated) =>
+          render(left) ++ render(right)
+
+        case Alternation(left, right: Sequence) =>
+          render(left) ++ render(right)
 
         case Alternation(left, right) =>
-          render(left) + Span.text("|") + render(right)
+          for {
+            l <- render(left)
+            r <- render(right)
+          } yield l + Span.text("|") + r
 
         case Mixed =>
-          Span.text("<command>")
+          Span.text("<command>") :: Nil
 
-        case None => Span.text("")
+        case None => Span.text("") :: Nil
       }
 
-    p(render(self))
+    render(simplify(self))
+  }
+
+  final def helpDoc: HelpDoc = enumerate match {
+    case Nil         => HelpDoc.empty
+    case head :: Nil => p(head)
+    case list        => list.map(p).foldRight(HelpDoc.empty)(_ + _)
   }
 
   final def optional: UsageSynopsis = UsageSynopsis.Optional(self)


### PR DESCRIPTION
/claim #236. The solution multiplies the synopsis when one side of `OrElse` is a Sequence (juxtaposition) or a Repeated (`opts ...`). In other cases like Optional it doesn't make two synopsis. Divisions are accumulated (Case 3.)

The output is the following:


Case 1.
```
(left | (right1 ++ right2)) ++ next
```
```
USAGE

  $ test --left <text> --next <text>

  $ test --right1 <text> --right2 <text> --next <text>
```

Case 2.
```
a | (b ++ (c | d).optional)
```
```
USAGE

  $ test -a <text>

  $ test -b <text> [-c <text>|-d <text>]
```

Case 3.
```
a | (b ++ (c | d ++ e).optional)
```
```
USAGE

  $ test -a <text>

  $ test -b <text> [-c <text>]

  $ test -b <text> [-d <text> -e <text>]

```