### PR TITLE
Testkit + changes in CliApp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'master' ]
+    branches: [ 'testkit' ]
   release:
     types:
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: [ 'testkit' ]
+    branches: [ 'master' ]
   release:
     types:
       - published

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,9 @@ lazy val root = project
     examplesJVM,
     examplesJS,
     docs,
-    sbtZioCli
+    sbtZioCli,
+    testkitJVM,
+    testkitJS
   )
 
 lazy val zioCli = crossProject(JSPlatform, JVMPlatform)
@@ -125,9 +127,9 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform)
   .settings(skip / publish := true)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio-test"     % zioVersion,
-      "dev.zio" %% "zio-test-sbt"     % zioVersion,
-      "dev.zio" %% "zio-test-magnolia"     % zioVersion
+      "dev.zio" %% "zio-test"          % zioVersion,
+      "dev.zio" %% "zio-test-sbt"      % zioVersion,
+      "dev.zio" %% "zio-test-magnolia" % zioVersion
     )
   )
   .dependsOn(zioCli)

--- a/build.sbt
+++ b/build.sbt
@@ -117,4 +117,25 @@ lazy val sbtZioCli = project
   )
   .enablePlugins(SbtPlugin)
 
+lazy val testkit = crossProject(JSPlatform, JVMPlatform)
+  .in(file("zio-cli-testkit"))
+  .settings(stdSettings("zio-cli-testkit"))
+  .settings(buildInfoSettings("zio.cli.testkit"))
+  .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
+  .settings(skip / publish := true)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-test"     % zioVersion,
+      "dev.zio" %% "zio-test-sbt"     % zioVersion,
+      "dev.zio" %% "zio-test-magnolia"     % zioVersion
+    )
+  )
+  .dependsOn(zioCli)
+
+lazy val testkitJVM = testkit.jvm
+  .settings(dottySettings)
+
+lazy val testkitJS = testkit.js
+  .settings(scalaJSUseMainModuleInitializer := true)
+
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/CliAssertion.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/CliAssertion.scala
@@ -1,0 +1,207 @@
+package zio.cli.testkit
+
+import zio.cli._
+import zio.cli.CliApp.CliAppImpl
+import zio.ZIO
+import zio.test._
+
+/**
+ * `CliAssertions` contains methods to test a particular `CliApp` or a particular `Command`.
+ * ??? Strategies
+ */
+
+
+object CliAssertion {
+
+  implicit val cliConfig: CliConfig = CliConfig.default
+
+
+  /**
+    * Allows to check any assertion on the `Command` instance employed in a `CliApp`.
+    * Better use only when other methods do not cover your use-case.
+    *
+    */
+  def accessCommand[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[Command[_]]): TestResult = 
+    cliApp match {
+      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command)
+    }
+
+  def accessHelpDoc[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[HelpDoc]): TestResult = 
+    cliApp match {
+      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command.helpDoc)
+    }
+    
+
+  def accessSynopsis[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[UsageSynopsis]): TestResult = 
+    cliApp match {
+      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command.synopsis)
+    }
+
+
+  /**
+    * Methods to test properties of the `Command` of a `CliApp`.
+    */
+
+  /**
+   * Checks the usage synopsis in `String` or `UsageSynopsis` form.
+   */
+  def assertSynopsis[A](command: Command[A], synopsis: String)(implicit cliConfig: CliConfig): TestResult = 
+    assertSynopsis(command, List(synopsis))
+
+  def assertSynopsis[A](command: Command[A], synopsis: List[String])(implicit cliConfig: CliConfig): TestResult = 
+    assertTrue(command.synopsis.enumerate(cliConfig).map(_.text) == synopsis)
+
+  def assertSynopsis[A](command: Command[A], synopsis: UsageSynopsis): TestResult =
+    assertSynopsis(command, synopsis.enumerate(CliConfig.default).map(_.text))(CliConfig.default)
+
+  def assertHelpDoc[A](command: Command[A], helpDoc: HelpDoc): TestResult = 
+    assertTrue(command.helpDoc.toHTML == helpDoc.toHTML)
+
+  
+
+  /**
+   * Checks the usage synopsis in `String` or `UsageSynopsis` form.
+   */
+  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: String)(implicit cliConfig: CliConfig): TestResult = 
+    assertSynopsis(cliApp, List(synopsis))
+
+  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: List[String])(implicit cliConfig: CliConfig): TestResult = 
+    cliApp match {
+      case CliAppImpl(_,_,_, command, _,_,_,_) => assertSynopsis(command, synopsis)
+    } 
+
+  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: UsageSynopsis): TestResult =
+    assertSynopsis(cliApp, synopsis.enumerate(CliConfig.default).map(_.text))
+
+
+  def assertHelpDoc[R, E, A](cliApp: CliApp[R, E, A], helpDoc: HelpDoc): TestResult = 
+    cliApp match {
+      case CliAppImpl(_,_,_, command, _,_,_,_) => assertHelpDoc(command, helpDoc)
+    }
+
+
+  /**
+   * Methods to assist property-based testing using `Gen`.
+   */
+
+  def assertCommandSuccess[A, R](
+    command: Command[A], 
+    pairs: Gen[R, CliRepr[List[String], Assertion[Either[ValidationError, A]]]]
+  )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] =
+    check(pairs) { case CliRepr(params, assertion) =>
+      command
+        .parse(params, cliConfig)
+        .map(Right(_))
+        .catchAll {
+          case e: ValidationError => ZIO.succeed(Left(e))
+        }
+        .flatMap {
+          case Right(CommandDirective.UserDefined(_, value)) => ZIO.succeed(Right(value))
+          case Right(_) => ZIO.fail(new Exception)
+          case Left(e) => ZIO.succeed(Left(e))
+        }
+        .map(assertion.run(_))
+    }
+
+  def assertCommandAll[A, R](
+    command: Command[A], 
+    pairs: Gen[R, CliRepr[List[String], Assertion[Either[ValidationError, TestReturn[A]]]]]
+    )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult]=
+    check(pairs) { case CliRepr(params, assertion) =>
+      command
+        .parse(params, cliConfig)
+        .map(TestReturn.convert)
+        .map(Right(_))
+        .catchSome {
+          case e: ValidationError => ZIO.succeed(Left(e))
+        }
+        .map(assertion.run(_))
+    }
+
+  def assertCliApp[R, E, A, RGen](
+    cliApp: CliApp[R, E, A], 
+    pairs: Gen[RGen, CliRepr[List[String], Assertion[A]]]
+  )(implicit cliConfig: CliConfig): ZIO[RGen with R, Throwable, TestResult] =
+    check(pairs) { case CliRepr(params, assertion) =>
+      cliApp.run(params).flatMap {
+        case Some(value) => ZIO.succeed(assertion.run(value))
+        case None => ZIO.fail(new Exception)
+      }
+    }
+
+
+  
+  def assertCommand[A, R](
+    command: Command[A], 
+    pairs: Gen[R, CliRepr[List[String], A]]
+    )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] = {
+
+    val assertion: A => Assertion[Either[ValidationError, A]] = a => Assertion.assertion("check")(_ == Right(a))
+
+    assertCommandSuccess[A, R](
+      command, 
+      pairs.map(_.map2(assertion))
+      )
+  }
+    
+
+  def assertCliAppValues[R, E, A, RGen](
+    cliApp: CliApp[R, E, A], 
+    pairs: Gen[RGen, CliRepr[List[String], A]]
+  )(implicit cliConfig: CliConfig): ZIO[RGen with R, Throwable, TestResult] =
+    assertCliApp(
+      cliApp, 
+      pairs.map(
+        _.map2{
+          case a => Assertion.equalTo(a)
+        }
+      )
+    )
+
+  def assertCliAppZIO[R, E, A, RGen](cliApp: CliApp[R, E, A], pairs: Gen[RGen, CliRepr[List[String], ZIO[R, E, A]]]): ZIO[RGen with R, Throwable, TestResult] = 
+    check(pairs) { case CliRepr(params, effect) =>
+      for {
+        cliRes <- cliApp
+          .run(params)
+          .map(Right(_))
+          .catchAll {
+            case e: CliError.Execution[E] => ZIO.succeed(Left(e))
+            case e => ZIO.fail(e)
+          }
+          .flatMap {
+            case Right(Some(value)) => ZIO.succeed(Right(value))
+            case Right(None) => ZIO.fail(new Exception)
+            case Left(e) => ZIO.succeed(Left(e))
+          }
+        realRes <- effect
+          .map(Right(_))
+          .catchAll {
+            case e => ZIO.succeed(Left(CliError.Execution(e)))
+          }
+      } yield assertTrue(realRes == cliRes)
+      
+
+    }
+
+/**
+  * Methods for Output and Input testing
+  */
+
+  /**
+    * Checks if the console output of a CliApp contains all the `String` from a `Seq[String]`.
+    */
+  def outputContains[R, E, A, RGen](cliApp: CliApp[R, E, A], pairs: Gen[RGen, CliRepr[List[String], Seq[String]]]): ZIO[RGen with R, Throwable, TestResult] = 
+    check(pairs) { case CliRepr(params, strings) => 
+      import zio.Console.readLine
+      for {
+        text <- cliApp.run(params) *> readLine
+      } yield assertTrue(strings.forall(text.contains(_)))    
+    }
+
+
+/**
+ * Methods ???
+ */
+
+  def complete[A, R](pairs: Gen[R, CliRepr[List[String], A]]): Gen[R, CliRepr[List[String], Either[CliError[Nothing], A]]] = ???
+}

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/CliAssertion.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/CliAssertion.scala
@@ -6,202 +6,224 @@ import zio.ZIO
 import zio.test._
 
 /**
- * `CliAssertions` contains methods to test a particular `CliApp` or a particular `Command`.
- * ??? Strategies
+ * `CliAssertions` contains methods to test a particular `CliApp` or a particular `Command`. It's possible to test
+ * directly a `Command` instance
  */
-
 
 object CliAssertion {
 
   implicit val cliConfig: CliConfig = CliConfig.default
 
+  /**
+   * Allows to check any assertion on the `Command` instance employed in a `CliApp`. Better use only when other methods
+   * do not cover your use-case.
+   */
+  def accessCommand[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[Command[_]]): TestResult =
+    cliApp match {
+      case CliAppImpl(_, _, _, command, _, _, _, _) => assert.run(command)
+    }
+
+  def accessHelpDoc[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[HelpDoc]): TestResult =
+    cliApp match {
+      case CliAppImpl(_, _, _, command, _, _, _, _) => assert.run(command.helpDoc)
+    }
+
+  def accessSynopsis[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[UsageSynopsis]): TestResult =
+    cliApp match {
+      case CliAppImpl(_, _, _, command, _, _, _, _) => assert.run(command.synopsis)
+    }
 
   /**
-    * Allows to check any assertion on the `Command` instance employed in a `CliApp`.
-    * Better use only when other methods do not cover your use-case.
-    *
-    */
-  def accessCommand[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[Command[_]]): TestResult = 
-    cliApp match {
-      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command)
-    }
-
-  def accessHelpDoc[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[HelpDoc]): TestResult = 
-    cliApp match {
-      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command.helpDoc)
-    }
-    
-
-  def accessSynopsis[R, E, A](cliApp: CliApp[R, E, A], assert: Assertion[UsageSynopsis]): TestResult = 
-    cliApp match {
-      case CliAppImpl(_,_,_, command, _,_,_,_) => assert.run(command.synopsis)
-    }
-
-
-  /**
-    * Methods to test properties of the `Command` of a `CliApp`.
-    */
+   * Methods to test properties of the `Command` of a `CliApp`.
+   */
 
   /**
    * Checks the usage synopsis in `String` or `UsageSynopsis` form.
    */
-  def assertSynopsis[A](command: Command[A], synopsis: String)(implicit cliConfig: CliConfig): TestResult = 
+  def assertSynopsis[A](command: Command[A], synopsis: String)(implicit cliConfig: CliConfig): TestResult =
     assertSynopsis(command, List(synopsis))
 
-  def assertSynopsis[A](command: Command[A], synopsis: List[String])(implicit cliConfig: CliConfig): TestResult = 
+  def assertSynopsis[A](command: Command[A], synopsis: List[String])(implicit cliConfig: CliConfig): TestResult =
     assertTrue(command.synopsis.enumerate(cliConfig).map(_.text) == synopsis)
 
   def assertSynopsis[A](command: Command[A], synopsis: UsageSynopsis): TestResult =
     assertSynopsis(command, synopsis.enumerate(CliConfig.default).map(_.text))(CliConfig.default)
 
-  def assertHelpDoc[A](command: Command[A], helpDoc: HelpDoc): TestResult = 
+  def assertHelpDoc[A](command: Command[A], helpDoc: HelpDoc): TestResult =
     assertTrue(command.helpDoc.toHTML == helpDoc.toHTML)
-
-  
 
   /**
    * Checks the usage synopsis in `String` or `UsageSynopsis` form.
    */
-  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: String)(implicit cliConfig: CliConfig): TestResult = 
+  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: String)(implicit cliConfig: CliConfig): TestResult =
     assertSynopsis(cliApp, List(synopsis))
 
-  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: List[String])(implicit cliConfig: CliConfig): TestResult = 
+  def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: List[String])(implicit
+    cliConfig: CliConfig
+  ): TestResult =
     cliApp match {
-      case CliAppImpl(_,_,_, command, _,_,_,_) => assertSynopsis(command, synopsis)
-    } 
+      case CliAppImpl(_, _, _, command, _, _, _, _) => assertSynopsis(command, synopsis)
+    }
 
   def assertSynopsis[R, E, A](cliApp: CliApp[R, E, A], synopsis: UsageSynopsis): TestResult =
     assertSynopsis(cliApp, synopsis.enumerate(CliConfig.default).map(_.text))
 
-
-  def assertHelpDoc[R, E, A](cliApp: CliApp[R, E, A], helpDoc: HelpDoc): TestResult = 
+  def assertHelpDoc[R, E, A](cliApp: CliApp[R, E, A], helpDoc: HelpDoc): TestResult =
     cliApp match {
-      case CliAppImpl(_,_,_, command, _,_,_,_) => assertHelpDoc(command, helpDoc)
+      case CliAppImpl(_, _, _, command, _, _, _, _) => assertHelpDoc(command, helpDoc)
     }
 
-
   /**
-   * Methods to assist property-based testing using `Gen`.
+   * Methods to assist property-based testing using `Gen` of a `Command`.
    */
 
+  /**
+   * Creates a TestResult from an Assertion over the result of parsing a command. It can test `ValidationError` produced
+   * during the parsing process and the value produced by the `Command` instance.
+   */
   def assertCommandSuccess[A, R](
-    command: Command[A], 
+    command: Command[A],
     pairs: Gen[R, CliRepr[List[String], Assertion[Either[ValidationError, A]]]]
   )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] =
     check(pairs) { case CliRepr(params, assertion) =>
       command
         .parse(params, cliConfig)
         .map(Right(_))
-        .catchAll {
-          case e: ValidationError => ZIO.succeed(Left(e))
+        .catchAll { case e: ValidationError =>
+          ZIO.succeed(Left(e))
         }
         .flatMap {
           case Right(CommandDirective.UserDefined(_, value)) => ZIO.succeed(Right(value))
-          case Right(_) => ZIO.fail(new Exception)
-          case Left(e) => ZIO.succeed(Left(e))
+          case Right(_)                                      => ZIO.fail(new Exception)
+          case Left(e)                                       => ZIO.succeed(Left(e))
         }
         .map(assertion.run(_))
     }
 
+  /**
+   * Creates a TestResult from an Assertion over the result of parsing a command. It can test `ValidationError` produced
+   * during the parsing process, the value produced by the `Command` instance and the triggering of built-in options.
+   */
   def assertCommandAll[A, R](
-    command: Command[A], 
+    command: Command[A],
     pairs: Gen[R, CliRepr[List[String], Assertion[Either[ValidationError, TestReturn[A]]]]]
-    )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult]=
+  )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] =
     check(pairs) { case CliRepr(params, assertion) =>
       command
         .parse(params, cliConfig)
         .map(TestReturn.convert)
         .map(Right(_))
-        .catchSome {
-          case e: ValidationError => ZIO.succeed(Left(e))
+        .catchSome { case e: ValidationError =>
+          ZIO.succeed(Left(e))
         }
         .map(assertion.run(_))
     }
 
-  def assertCliApp[R, E, A, RGen](
-    cliApp: CliApp[R, E, A], 
-    pairs: Gen[RGen, CliRepr[List[String], Assertion[A]]]
-  )(implicit cliConfig: CliConfig): ZIO[RGen with R, Throwable, TestResult] =
-    check(pairs) { case CliRepr(params, assertion) =>
-      cliApp.run(params).flatMap {
-        case Some(value) => ZIO.succeed(assertion.run(value))
-        case None => ZIO.fail(new Exception)
-      }
-    }
-
-
-  
+  /**
+   * Tests the value produced by the `Command` instance. It fails when there is a `ValidationError`.
+   */
   def assertCommand[A, R](
-    command: Command[A], 
+    command: Command[A],
     pairs: Gen[R, CliRepr[List[String], A]]
-    )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] = {
+  )(implicit cliConfig: CliConfig): ZIO[R, Throwable, TestResult] = {
 
     val assertion: A => Assertion[Either[ValidationError, A]] = a => Assertion.assertion("check")(_ == Right(a))
 
     assertCommandSuccess[A, R](
-      command, 
+      command,
       pairs.map(_.map2(assertion))
-      )
+    )
   }
-    
 
+  /**
+   * Methods to test a `CliApp` instance.
+   */
+
+  /**
+   * Creates a TestResult from an Assertion over the result of running a command on a `CliApp`. It can test errors and
+   * values produced by the `CliApp`.
+   */
+  def assertCliApp[R, E, A, RGen](
+    cliApp: CliApp[R, E, A],
+    pairs: Gen[RGen, CliRepr[List[String], Assertion[Either[CliError[E], A]]]]
+  )(implicit cliConfig: CliConfig): ZIO[RGen with R, Throwable, TestResult] =
+    check(pairs) { case CliRepr(params, assertion) =>
+      cliApp
+        .run(params)
+        .map(Right(_))
+        .catchAll { case e: CliError[E] =>
+          ZIO.succeed(Left(e))
+        }
+        .flatMap {
+          case Right(Some(value)) => ZIO.succeed(Right(value))
+          case Right(None)        => ZIO.fail(new Exception)
+          case Left(e)            => ZIO.succeed(Left(e))
+        }
+        .map(assertion.run(_))
+    }
+
+  /**
+   * Creates a TestResult to test the output of a `CliApp`.
+   */
   def assertCliAppValues[R, E, A, RGen](
-    cliApp: CliApp[R, E, A], 
+    cliApp: CliApp[R, E, A],
     pairs: Gen[RGen, CliRepr[List[String], A]]
   )(implicit cliConfig: CliConfig): ZIO[RGen with R, Throwable, TestResult] =
-    assertCliApp(
-      cliApp, 
+    assertCliApp[R, E, A, RGen](
+      cliApp,
       pairs.map(
-        _.map2{
-          case a => Assertion.equalTo(a)
+        _.map2 { case a =>
+          Assertion.equalTo(Right(a))
         }
       )
     )
 
-  def assertCliAppZIO[R, E, A, RGen](cliApp: CliApp[R, E, A], pairs: Gen[RGen, CliRepr[List[String], ZIO[R, E, A]]]): ZIO[RGen with R, Throwable, TestResult] = 
+  /**
+   * Creates a TestResult to test the output of a `CliApp` using a ZIO effect.
+   */
+  def assertCliAppZIO[R, E, A, RGen](
+    cliApp: CliApp[R, E, A],
+    pairs: Gen[RGen, CliRepr[List[String], ZIO[R, E, A]]]
+  ): ZIO[RGen with R, Throwable, TestResult] =
     check(pairs) { case CliRepr(params, effect) =>
       for {
         cliRes <- cliApp
-          .run(params)
-          .map(Right(_))
-          .catchAll {
-            case e: CliError.Execution[E] => ZIO.succeed(Left(e))
-            case e => ZIO.fail(e)
-          }
-          .flatMap {
-            case Right(Some(value)) => ZIO.succeed(Right(value))
-            case Right(None) => ZIO.fail(new Exception)
-            case Left(e) => ZIO.succeed(Left(e))
-          }
+                    .run(params)
+                    .map(Right(_))
+                    .catchAll {
+                      case e: CliError.Execution[E] => ZIO.succeed(Left(e))
+                      case e                        => ZIO.fail(e)
+                    }
+                    .flatMap {
+                      case Right(Some(value)) => ZIO.succeed(Right(value))
+                      case Right(None)        => ZIO.fail(new Exception)
+                      case Left(e)            => ZIO.succeed(Left(e))
+                    }
         realRes <- effect
-          .map(Right(_))
-          .catchAll {
-            case e => ZIO.succeed(Left(CliError.Execution(e)))
-          }
+                     .map(Right(_))
+                     .catchAll { case e =>
+                       ZIO.succeed(Left(CliError.Execution(e)))
+                     }
       } yield assertTrue(realRes == cliRes)
-      
 
     }
-
-/**
-  * Methods for Output and Input testing
-  */
 
   /**
-    * Checks if the console output of a CliApp contains all the `String` from a `Seq[String]`.
-    */
-  def outputContains[R, E, A, RGen](cliApp: CliApp[R, E, A], pairs: Gen[RGen, CliRepr[List[String], Seq[String]]]): ZIO[RGen with R, Throwable, TestResult] = 
-    check(pairs) { case CliRepr(params, strings) => 
-      import zio.Console.readLine
+   * Methods for Output and Input testing
+   */
+
+  /**
+   * Checks if the console output of a CliApp contains all the `String` from a `Seq[String]`.
+   */
+  def outputContains[R, E, A, RGen](
+    cliApp: CliApp[R, E, A],
+    pairs: Gen[RGen, CliRepr[List[String], Seq[String]]]
+  ): ZIO[RGen with R, Throwable, TestResult] =
+    check(pairs) { case CliRepr(params, strings) =>
       for {
-        text <- cliApp.run(params) *> readLine
-      } yield assertTrue(strings.forall(text.contains(_)))    
+        _    <- cliApp.run(params)
+        text <- zio.test.TestConsole.output
+      } yield assertTrue(strings.forall(word => text.map(_.contains(word)).contains(true)))
     }
 
-
-/**
- * Methods ???
- */
-
-  def complete[A, R](pairs: Gen[R, CliRepr[List[String], A]]): Gen[R, CliRepr[List[String], Either[CliError[Nothing], A]]] = ???
 }

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/CliRepr.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/CliRepr.scala
@@ -1,0 +1,14 @@
+package zio.cli.testkit
+
+/**
+ * `CliRepr(a, repr)` represents a value `a` constructed using the cli package and
+ * the correct representation `repr`. 
+ */
+
+final case class CliRepr[+A, +R](value: A, repr: R) {
+
+  def map[B](f: (A => B)) = CliRepr[B, R](f(value), repr)
+
+  def map2[B](f: (R => B)) = CliRepr[A, B](value, f(repr))
+
+}

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/CliRepr.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/CliRepr.scala
@@ -1,8 +1,7 @@
 package zio.cli.testkit
 
 /**
- * `CliRepr(a, repr)` represents a value `a` constructed using the cli package and
- * the correct representation `repr`. 
+ * `CliRepr(a, repr)` represents a value `a` constructed using the cli package and the correct representation `repr`.
  */
 
 final case class CliRepr[+A, +R](value: A, repr: R) {

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/GenerationAssertion.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/GenerationAssertion.scala
@@ -1,0 +1,51 @@
+package zio.cli.testkit
+
+import zio.cli._
+import zio.test._
+import zio.ZIO
+
+/**
+  * `GenerationAssertion` contains methods to test the a function returning `CliApp` or `Command`.
+  */
+
+object GenerationAssertion {
+
+  implicit val cliConfig: CliConfig = CliConfig.default
+
+  def commandCreation[A, B, R1, R2](
+    f: A => Command[B], 
+    response: Gen[R1, (A, Gen[R2, CliRepr[List[String], B]])]
+    )(implicit cliConfig: CliConfig): ZIO[R1 with R2, Throwable, TestResult] =
+    check(response) { case (seed, resp) =>
+      CliAssertion.assertCommand[B, R2](f(seed), resp)
+    }
+
+  def commandCreationZIO[A, B, R, E <: Throwable, RGen1, RGen2](
+    f: A => ZIO[R, E, Command[B]], 
+    response: Gen[RGen1, (A, Gen[RGen2, CliRepr[List[String], B]])]
+  ): ZIO[R with RGen1 with RGen2, Throwable, TestResult] =
+    check(response) { case (seed, resp) =>
+      for {
+        command <- f(seed)
+        testRes <- CliAssertion.assertCommand[B, RGen2](command, resp)
+      } yield testRes
+    }
+
+  
+
+  def cliAppCreation[R, E, A, B, RGen](f: A => CliApp[R, E, B], response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]): ZIO[R with RGen, Throwable, TestResult] =
+    check(response) { case (seed, resp) =>
+      CliAssertion.assertCliAppValues[R, E, B, RGen](f(seed), resp)
+    }
+
+  def cliAppCreationZIO[R, E, A, B, RGen, RC, EC <: Throwable](f: A => ZIO[RC, EC, CliApp[R, E, B]], response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]): ZIO[R with RC with RGen, Throwable, TestResult] =
+    check(response) { case (seed, resp) =>
+      for {
+        cliApp <- f(seed)
+        testRes <- CliAssertion.assertCliAppValues[R, E, B, RGen](cliApp, resp)
+      } yield testRes     
+    }
+
+
+
+}

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/GenerationAssertion.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/GenerationAssertion.scala
@@ -5,23 +5,29 @@ import zio.test._
 import zio.ZIO
 
 /**
-  * `GenerationAssertion` contains methods to test the a function returning `CliApp` or `Command`.
-  */
+ * `GenerationAssertion` contains methods to test the a function returning `CliApp` or `Command`.
+ */
 
 object GenerationAssertion {
 
   implicit val cliConfig: CliConfig = CliConfig.default
 
+  /**
+   * Methods to test generation of `Command` from a function. `response` is a generator of pairs of seeds of type `A`
+   * for the function and generators to test the `Command`. Thus, `response` generates tuples `(seed, res)` where `seed`
+   * is used to generate a `Command` and `res` is used to test said `Command`. `res` is itself a generator of
+   * `CliRepr[List[String], B]`, that is, pairs of a given command and its corresponding output.
+   */
   def commandCreation[A, B, R1, R2](
-    f: A => Command[B], 
+    f: A => Command[B],
     response: Gen[R1, (A, Gen[R2, CliRepr[List[String], B]])]
-    )(implicit cliConfig: CliConfig): ZIO[R1 with R2, Throwable, TestResult] =
+  )(implicit cliConfig: CliConfig): ZIO[R1 with R2, Throwable, TestResult] =
     check(response) { case (seed, resp) =>
       CliAssertion.assertCommand[B, R2](f(seed), resp)
     }
 
   def commandCreationZIO[A, B, R, E <: Throwable, RGen1, RGen2](
-    f: A => ZIO[R, E, Command[B]], 
+    f: A => ZIO[R, E, Command[B]],
     response: Gen[RGen1, (A, Gen[RGen2, CliRepr[List[String], B]])]
   ): ZIO[R with RGen1 with RGen2, Throwable, TestResult] =
     check(response) { case (seed, resp) =>
@@ -31,21 +37,29 @@ object GenerationAssertion {
       } yield testRes
     }
 
-  
-
-  def cliAppCreation[R, E, A, B, RGen](f: A => CliApp[R, E, B], response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]): ZIO[R with RGen, Throwable, TestResult] =
+  /**
+   * Methods to test generation of `CliApp` from a function. `response` is a generator of pairs of seeds of type `A` for
+   * the function and generators to test the `CliApp`. Thus, `response` generates tuples `(seed, res)` where `seed` is
+   * used to generate a `CliApp` and `res` is used to test said `CliApp`. `res` is itself a generator of
+   * `CliRepr[List[String], B]`, that is, pairs of a given command and its corresponding output.
+   */
+  def cliAppCreation[R, E, A, B, RGen](
+    f: A => CliApp[R, E, B],
+    response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]
+  ): ZIO[R with RGen, Throwable, TestResult] =
     check(response) { case (seed, resp) =>
       CliAssertion.assertCliAppValues[R, E, B, RGen](f(seed), resp)
     }
 
-  def cliAppCreationZIO[R, E, A, B, RGen, RC, EC <: Throwable](f: A => ZIO[RC, EC, CliApp[R, E, B]], response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]): ZIO[R with RC with RGen, Throwable, TestResult] =
+  def cliAppCreationZIO[R, E, A, B, RGen, RC, EC <: Throwable](
+    f: A => ZIO[RC, EC, CliApp[R, E, B]],
+    response: Gen[RGen, (A, Gen[RGen, CliRepr[List[String], B]])]
+  ): ZIO[R with RC with RGen, Throwable, TestResult] =
     check(response) { case (seed, resp) =>
       for {
-        cliApp <- f(seed)
+        cliApp  <- f(seed)
         testRes <- CliAssertion.assertCliAppValues[R, E, B, RGen](cliApp, resp)
-      } yield testRes     
+      } yield testRes
     }
-
-
 
 }

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/TestReturn.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/TestReturn.scala
@@ -1,0 +1,28 @@
+package zio.cli.testkit
+
+import zio.cli.CommandDirective
+import zio.cli.CommandDirective._
+
+sealed trait TestReturn[+A]
+
+object TestReturn {
+
+    def convert[A](res: CommandDirective[A]): TestReturn[A] =
+        res match {
+          case UserDefined(_, value) => Value[A](value)
+          case BuiltIn(_) => Help()//???
+        }
+
+    sealed trait BuiltIn extends TestReturn[Nothing]
+
+    case class Help() extends BuiltIn
+    case class Wizard() extends BuiltIn
+    case class SH() extends BuiltIn
+    case class SHH() extends BuiltIn
+
+    case class Value[A](a: A) extends TestReturn[A]
+
+}
+
+
+

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/TestReturn.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/TestReturn.scala
@@ -7,22 +7,19 @@ sealed trait TestReturn[+A]
 
 object TestReturn {
 
-    def convert[A](res: CommandDirective[A]): TestReturn[A] =
-        res match {
-          case UserDefined(_, value) => Value[A](value)
-          case BuiltIn(_) => Help()//???
-        }
+  def convert[A](res: CommandDirective[A]): TestReturn[A] =
+    res match {
+      case UserDefined(_, value) => Value[A](value)
+      case BuiltIn(_)            => Help()
+    }
 
-    sealed trait BuiltIn extends TestReturn[Nothing]
+  sealed trait BuiltIn extends TestReturn[Nothing]
 
-    case class Help() extends BuiltIn
-    case class Wizard() extends BuiltIn
-    case class SH() extends BuiltIn
-    case class SHH() extends BuiltIn
+  case class Help()   extends BuiltIn
+  case class Wizard() extends BuiltIn
+  case class SH()     extends BuiltIn
+  case class SHH()    extends BuiltIn
 
-    case class Value[A](a: A) extends TestReturn[A]
+  case class Value[A](a: A) extends TestReturn[A]
 
 }
-
-
-

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/Tree.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/Tree.scala
@@ -10,7 +10,7 @@ final case class Tree[A](
   atoms: List[Gen[Any, A]],
   mappers: List[Tree.Mapper[A, Any]],
   operators: List[((A, A) => A)],
-  depth: Int,
+  depth: Int
 ) {
 
   def gen: Gen[Any, A] = for {
@@ -24,7 +24,7 @@ final case class Tree[A](
     if (depth <= 0)
       anyAtom
     else {
-      val genMappers   = mappers.map { case Tree.Mapper(f, anyB) =>
+      val genMappers = mappers.map { case Tree.Mapper(f, anyB) =>
         anyTree(depth - 1).zip(anyB).map { case (a, b) =>
           f(a, b)
         }
@@ -34,7 +34,7 @@ final case class Tree[A](
           f(a, b)
         }
       }
-      val gens         = genMappers ++ genOperators
+      val gens = genMappers ++ genOperators
       Gen.oneOf(gens: _*)
     }
 }

--- a/zio-cli-testkit/shared/src/main/scala/zio/cli/Tree.scala
+++ b/zio-cli-testkit/shared/src/main/scala/zio/cli/Tree.scala
@@ -1,0 +1,48 @@
+package zio.cli.testkit
+
+import zio.test.Gen
+
+/**
+ * `Tree` helps constructing a generator `Gen` with desired depth of a tree structure
+ */
+
+final case class Tree[A](
+  atoms: List[Gen[Any, A]],
+  mappers: List[Tree.Mapper[A, Any]],
+  operators: List[((A, A) => A)],
+  depth: Int,
+) {
+
+  def gen: Gen[Any, A] = for {
+    treeDepth <- Gen.bounded(0, 2)(Gen.const(_))
+    tree      <- anyTree(treeDepth)
+  } yield tree
+
+  lazy val anyAtom: Gen[Any, A] = Gen.oneOf(atoms: _*)
+
+  def anyTree(depth: Int): Gen[Any, A] =
+    if (depth <= 0)
+      anyAtom
+    else {
+      val genMappers   = mappers.map { case Tree.Mapper(f, anyB) =>
+        anyTree(depth - 1).zip(anyB).map { case (a, b) =>
+          f(a, b)
+        }
+      }
+      val genOperators = operators.map { case f =>
+        anyTree(depth - 1).zip(anyTree(depth - 1)).map { case (a, b) =>
+          f(a, b)
+        }
+      }
+      val gens         = genMappers ++ genOperators
+      Gen.oneOf(gens: _*)
+    }
+}
+
+object Tree {
+
+  final case class Compare[A, Repr](a: A, repr: Repr)
+
+  final case class Mapper[A, B](f: ((A, B) => A), anyB: Gen[Any, B])
+
+}

--- a/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
+++ b/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
@@ -1,0 +1,91 @@
+package zio.cli.testkit
+
+import zio.test._
+import zio.cli._
+import zio.cli.testkit.CliAssertion._
+import zio.ZIO
+
+object CliAssertionSpec extends ZIOSpecDefault {
+
+    val synopsis1 = "command --opt1 text"
+    val command1 = Command("command", Options.text("opt1"))
+
+    val cliApp1 = CliApp.make("sample", "0",HelpDoc.Span.empty, command1)(x => ZIO.succeed(s"Options1: $x"))
+
+    val spec = suite("CliAssertions")(
+        suite("Access methods")(
+            test("accessCommand"){
+
+                val assertion: Assertion[Command[_]] = Assertion.equalTo(Command("command", Options.text("opt1")))
+
+                accessCommand(cliApp1, assertion)
+            },
+            test("accessHelpDoc"){
+                val assertion: Assertion[HelpDoc] = Assertion.equalTo(HelpDoc.empty)
+
+                accessHelpDoc(cliApp1, assertion)
+            },
+            test("accessSynopsis"){
+                val assertion: Assertion[UsageSynopsis] = Assertion(
+                    TestArrow.fromFunction[UsageSynopsis, Boolean](usageSynopsis => usageSynopsis.enumerate(CliConfig.default) == List("command --opt1 text"))
+                )
+
+                accessSynopsis(cliApp1, assertion)
+            },
+        ),
+        suite("Assert methods")(
+            test("assertSynopsis"){
+                assertSynopsis(cliApp1, synopsis1)
+                assertSynopsis(cliApp1, synopsis1 :: Nil)
+                assertSynopsis(cliApp1, UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("opt1"), Some("text")))
+                assertSynopsis(command1, synopsis1)
+                assertSynopsis(command1, synopsis1 :: Nil)
+                assertSynopsis(command1, UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("opt1"), Some("text")))
+
+            },
+            test("assertHelpDoc"){
+                assertHelpDoc(cliApp1, HelpDoc.empty)
+                assertHelpDoc(command1, HelpDoc.empty)
+
+            },
+            test("assertCommand"){
+                val gen: Gen[Any, CliRepr[List[String], String]] = Gen.fromIterable(
+                    List((List("command", "--opt1", "a"), "a"), (List("command", "--opt1", "asd"), "asd"), (List("command", "--opt1", ""), ""))
+                    ).map {
+                    case (x, y) => CliRepr(x, y)
+                }
+
+                assertCommand(command1, gen)
+                assertCommandAll[String, Any](
+                    command1, 
+                    gen.map(
+                        _.map2{
+                            case a: String => Assertion.equalTo(Right(TestReturn.Value(a)))
+                        }
+                    )
+                )
+            },
+            test("assertCliApp"){
+                val gen1: Gen[Any, CliRepr[List[String], String]] = Gen.fromIterable(
+                    List((List("command", "--opt1", "a"), "a"), (List("command", "--opt1", "asd"), "asd"), (List("command", "--opt1", ""), ""))
+                    ).map {
+                    case (x, y) => CliRepr(x, y)
+                }
+
+                val gen2: Gen[Any, CliRepr[List[String], Assertion[String]]] = Gen.fromIterable(
+                    List((List("command", "--opt1", "a"), Assertion.equalTo("a")), (List("command", "--opt1", "asd"), Assertion.equalTo("asd")), (List("command", "--opt1", ""), Assertion.equalTo("")))
+                    ).map {
+                    case (x, y) => CliRepr(x, y)
+                }
+
+                val gen3: Gen[Any, CliRepr[List[String], ZIO[Any, Nothing, String]]] = gen1.map(_.map2(ZIO.succeed(_)))
+
+                assertCliAppValues(cliApp1, gen1)
+                assertCliApp(cliApp1, gen2)
+                assertCliAppZIO(cliApp1, gen3)
+            }
+        )
+
+    )
+
+}

--- a/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
+++ b/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
@@ -17,12 +17,6 @@ object CliAssertionSpec extends ZIOSpecDefault {
     suite("Access methods")(
       test("accessCommand") {
 
-        /*def equal(command: Command[_]): Boolean = {
-            println(command.toString())
-            println(Command("command", Options.text("opt1")).toString())
-            command.toString() == Command("command", Options.text("opt1")).toString()
-        }*/
-
         val assertion: Assertion[Command[_]] =
           Assertion(TestArrow.fromFunction { case command =>
             command.names.contains("command")

--- a/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
+++ b/zio-cli-testkit/shared/src/test/scala/zio/cli/CliAssertionSpec.scala
@@ -4,88 +4,121 @@ import zio.test._
 import zio.cli._
 import zio.cli.testkit.CliAssertion._
 import zio.ZIO
+import zio.Console._
 
 object CliAssertionSpec extends ZIOSpecDefault {
 
-    val synopsis1 = "command --opt1 text"
-    val command1 = Command("command", Options.text("opt1"))
+  val synopsis1 = "command --opt1 text"
+  val command1  = Command("command", Options.text("opt1"))
 
-    val cliApp1 = CliApp.make("sample", "0",HelpDoc.Span.empty, command1)(x => ZIO.succeed(s"Options1: $x"))
+  val cliApp1 = CliApp.make("sample", "0", HelpDoc.Span.empty, command1)(x => ZIO.succeed(s"Options1: $x"))
 
-    val spec = suite("CliAssertions")(
-        suite("Access methods")(
-            test("accessCommand"){
+  val spec = suite("CliAssertionSpec")(
+    suite("Access methods")(
+      test("accessCommand") {
 
-                val assertion: Assertion[Command[_]] = Assertion.equalTo(Command("command", Options.text("opt1")))
+        /*def equal(command: Command[_]): Boolean = {
+            println(command.toString())
+            println(Command("command", Options.text("opt1")).toString())
+            command.toString() == Command("command", Options.text("opt1")).toString()
+        }*/
 
-                accessCommand(cliApp1, assertion)
-            },
-            test("accessHelpDoc"){
-                val assertion: Assertion[HelpDoc] = Assertion.equalTo(HelpDoc.empty)
+        val assertion: Assertion[Command[_]] =
+          Assertion(TestArrow.fromFunction { case command =>
+            command.names.contains("command")
+          })
 
-                accessHelpDoc(cliApp1, assertion)
-            },
-            test("accessSynopsis"){
-                val assertion: Assertion[UsageSynopsis] = Assertion(
-                    TestArrow.fromFunction[UsageSynopsis, Boolean](usageSynopsis => usageSynopsis.enumerate(CliConfig.default) == List("command --opt1 text"))
-                )
+        accessCommand(cliApp1, assertion)
+      },
+      test("accessHelpDoc") {
+        val assertion: Assertion[HelpDoc] = Assertion.equalTo(Command("command", Options.text("opt1")).helpDoc)
 
-                accessSynopsis(cliApp1, assertion)
-            },
-        ),
-        suite("Assert methods")(
-            test("assertSynopsis"){
-                assertSynopsis(cliApp1, synopsis1)
-                assertSynopsis(cliApp1, synopsis1 :: Nil)
-                assertSynopsis(cliApp1, UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("opt1"), Some("text")))
-                assertSynopsis(command1, synopsis1)
-                assertSynopsis(command1, synopsis1 :: Nil)
-                assertSynopsis(command1, UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("opt1"), Some("text")))
-
-            },
-            test("assertHelpDoc"){
-                assertHelpDoc(cliApp1, HelpDoc.empty)
-                assertHelpDoc(command1, HelpDoc.empty)
-
-            },
-            test("assertCommand"){
-                val gen: Gen[Any, CliRepr[List[String], String]] = Gen.fromIterable(
-                    List((List("command", "--opt1", "a"), "a"), (List("command", "--opt1", "asd"), "asd"), (List("command", "--opt1", ""), ""))
-                    ).map {
-                    case (x, y) => CliRepr(x, y)
-                }
-
-                assertCommand(command1, gen)
-                assertCommandAll[String, Any](
-                    command1, 
-                    gen.map(
-                        _.map2{
-                            case a: String => Assertion.equalTo(Right(TestReturn.Value(a)))
-                        }
-                    )
-                )
-            },
-            test("assertCliApp"){
-                val gen1: Gen[Any, CliRepr[List[String], String]] = Gen.fromIterable(
-                    List((List("command", "--opt1", "a"), "a"), (List("command", "--opt1", "asd"), "asd"), (List("command", "--opt1", ""), ""))
-                    ).map {
-                    case (x, y) => CliRepr(x, y)
-                }
-
-                val gen2: Gen[Any, CliRepr[List[String], Assertion[String]]] = Gen.fromIterable(
-                    List((List("command", "--opt1", "a"), Assertion.equalTo("a")), (List("command", "--opt1", "asd"), Assertion.equalTo("asd")), (List("command", "--opt1", ""), Assertion.equalTo("")))
-                    ).map {
-                    case (x, y) => CliRepr(x, y)
-                }
-
-                val gen3: Gen[Any, CliRepr[List[String], ZIO[Any, Nothing, String]]] = gen1.map(_.map2(ZIO.succeed(_)))
-
-                assertCliAppValues(cliApp1, gen1)
-                assertCliApp(cliApp1, gen2)
-                assertCliAppZIO(cliApp1, gen3)
-            }
+        accessHelpDoc(cliApp1, assertion)
+      },
+      test("accessSynopsis") {
+        val assertion: Assertion[UsageSynopsis] = Assertion(
+          TestArrow.fromFunction[UsageSynopsis, Boolean](usageSynopsis =>
+            usageSynopsis.enumerate(CliConfig.default).map(_.text) == List("command --opt1 <text>")
+          )
         )
 
-    )
+        accessSynopsis(cliApp1, assertion)
+      }
+    ),
+    suite("Assert methods")(
+      test("assertSynopsis") {
+        assertSynopsis(cliApp1, synopsis1)
+        assertSynopsis(cliApp1, synopsis1 :: Nil)
+        assertSynopsis(
+          cliApp1,
+          UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("--opt1"), Some("<text>"))
+        )
+        assertSynopsis(command1, synopsis1)
+        assertSynopsis(command1, synopsis1 :: Nil)
+        assertSynopsis(
+          command1,
+          UsageSynopsis.Named(List("command"), None) + UsageSynopsis.Named(List("--opt1"), Some("<text>"))
+        )
+
+      },
+      test("assertHelpDoc") {
+        assertHelpDoc(cliApp1, Command("command", Options.text("opt1")).helpDoc)
+        assertHelpDoc(command1, Command("command", Options.text("opt1")).helpDoc)
+
+      },
+      test("assertCommand") {
+        val gen: Gen[Any, CliRepr[List[String], String]] = Gen
+          .fromIterable(
+            List(
+              (List("command", "--opt1", "a"), "a"),
+              (List("command", "--opt1", "asd"), "asd")
+            )
+          )
+          .map { case (x, y) =>
+            CliRepr(x, y)
+          }
+
+        assertCommand(command1, gen)
+        assertCommandAll[String, Any](
+          command1,
+          gen.map(
+            _.map2 { case a: String =>
+              Assertion.equalTo(Right(TestReturn.Value(a)))
+            }
+          )
+        )
+      },
+      test("assertCliApp") {
+        val gen1: Gen[Any, CliRepr[List[String], String]] = Gen
+          .fromIterable(
+            List(
+              (List("--opt1", "a"), "Options1: a"),
+              (List("--opt1", "asd"), "Options1: asd")
+            )
+          )
+          .map { case (x, y) =>
+            CliRepr(x, y)
+          }
+
+        val gen2: Gen[Any, CliRepr[List[String], ZIO[Any, Nothing, String]]] = gen1.map(_.map2(ZIO.succeed(_)))
+
+        assertCliAppValues(cliApp1, gen1)
+        assertCliAppZIO(cliApp1, gen2)
+      }
+    ),
+    test("outputContains") {
+      val newCli = cliApp1.flatMap(x => printLine("a") *> printLine("b") *> printLine(s"c $x"))
+
+      val pairs: Gen[Any, CliRepr[List[String], List[String]]] =
+        Gen.fromIterable(
+          List(
+            CliRepr(List("--opt1", "asd"), "asd" :: Nil),
+            CliRepr(List("--opt1", "asd"), "b" :: Nil)
+          )
+        )
+
+      outputContains(newCli, pairs)
+    }
+  )
 
 }

--- a/zio-cli-testkit/shared/src/test/scala/zio/cli/GenerationAssertionSpec.scala
+++ b/zio-cli-testkit/shared/src/test/scala/zio/cli/GenerationAssertionSpec.scala
@@ -1,0 +1,66 @@
+package zio.cli.testkit
+
+import zio.test._
+import zio.cli._
+import zio.cli.testkit.GenerationAssertion._
+import zio.ZIO
+
+
+object GenerationAssertionSpec extends ZIOSpecDefault {
+
+    
+  
+    val spec = suite("GenerationAssertionSpec")(
+        test("commandCreation"){
+
+            def createCommand(header: String): Command[String] = Command(header, Options.text("opt1")).map(x => s"$header: $x")
+
+            def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
+                Gen.fromIterable(List("a", "ba", ""))
+                    .map {
+                        case param => CliRepr(
+                            List(header, "--opt1", param),
+                            s"$header: $param"
+                        )
+                    }
+
+            val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
+                Gen.fromIterable(List("header1", "header2")).map {
+                    case header => (header, createGen(header))
+                }
+
+            commandCreation(createCommand _, gen)
+            commandCreationZIO((x: String) => ZIO.succeed(createCommand(x)), gen)
+        },
+        test("cliAppCreation"){
+
+            def createCliApp(header: String): CliApp[Any, Nothing, String] = CliApp.make(
+                "name",
+                "version",
+                HelpDoc.Span.empty,
+                Command(header, Options.text("opt1")).map(x => s"$header: $x")
+            ){
+                case x => ZIO.succeed(x)
+            }
+
+            def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
+                Gen.fromIterable(List("a", "ba", ""))
+                    .map {
+                        case param => CliRepr(
+                            List(header, "--opt1", param),
+                            s"$header: $param"
+                        )
+                    }
+
+            val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
+                Gen.fromIterable(List("header1", "header2")).map {
+                    case header => (header, createGen(header))
+                }
+
+            cliAppCreation(createCliApp _, gen)
+            cliAppCreation(createCliApp _, gen)
+
+        }
+    )
+
+}

--- a/zio-cli-testkit/shared/src/test/scala/zio/cli/GenerationAssertionSpec.scala
+++ b/zio-cli-testkit/shared/src/test/scala/zio/cli/GenerationAssertionSpec.scala
@@ -5,62 +5,58 @@ import zio.cli._
 import zio.cli.testkit.GenerationAssertion._
 import zio.ZIO
 
-
 object GenerationAssertionSpec extends ZIOSpecDefault {
 
-    
-  
-    val spec = suite("GenerationAssertionSpec")(
-        test("commandCreation"){
+  val spec = suite("GenerationAssertionSpec")(
+    test("commandCreation") {
 
-            def createCommand(header: String): Command[String] = Command(header, Options.text("opt1")).map(x => s"$header: $x")
+      def createCommand(header: String): Command[String] =
+        Command(header, Options.text("opt1")).map(x => s"$header: $x")
 
-            def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
-                Gen.fromIterable(List("a", "ba", ""))
-                    .map {
-                        case param => CliRepr(
-                            List(header, "--opt1", param),
-                            s"$header: $param"
-                        )
-                    }
-
-            val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
-                Gen.fromIterable(List("header1", "header2")).map {
-                    case header => (header, createGen(header))
-                }
-
-            commandCreation(createCommand _, gen)
-            commandCreationZIO((x: String) => ZIO.succeed(createCommand(x)), gen)
-        },
-        test("cliAppCreation"){
-
-            def createCliApp(header: String): CliApp[Any, Nothing, String] = CliApp.make(
-                "name",
-                "version",
-                HelpDoc.Span.empty,
-                Command(header, Options.text("opt1")).map(x => s"$header: $x")
-            ){
-                case x => ZIO.succeed(x)
-            }
-
-            def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
-                Gen.fromIterable(List("a", "ba", ""))
-                    .map {
-                        case param => CliRepr(
-                            List(header, "--opt1", param),
-                            s"$header: $param"
-                        )
-                    }
-
-            val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
-                Gen.fromIterable(List("header1", "header2")).map {
-                    case header => (header, createGen(header))
-                }
-
-            cliAppCreation(createCliApp _, gen)
-            cliAppCreation(createCliApp _, gen)
-
+      def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
+        Gen.fromIterable(List("a", "ba", "")).map { case param =>
+          CliRepr(
+            List(header, "--opt1", param),
+            s"$header: $param"
+          )
         }
-    )
+
+      val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
+        Gen.fromIterable(List("header1", "header2")).map { case header =>
+          (header, createGen(header))
+        }
+
+      commandCreation(createCommand _, gen)
+      commandCreationZIO((x: String) => ZIO.succeed(createCommand(x)), gen)
+    },
+    test("cliAppCreation") {
+
+      def createCliApp(header: String): CliApp[Any, Nothing, String] = CliApp.make(
+        "name",
+        "version",
+        HelpDoc.Span.empty,
+        Command(header, Options.text("opt1")).map(x => s"$header: $x")
+      ) { case x =>
+        ZIO.succeed(x)
+      }
+
+      def createGen(header: String): Gen[Any, CliRepr[List[String], String]] =
+        Gen.fromIterable(List("a", "ba", "")).map { case param =>
+          CliRepr(
+            List("--opt1", param),
+            s"$header: $param"
+          )
+        }
+
+      val gen: Gen[Any, (String, Gen[Any, CliRepr[List[String], String]])] =
+        Gen.fromIterable(List("header1", "header2")).map { case header =>
+          (header, createGen(header))
+        }
+
+      cliAppCreation(createCliApp _, gen)
+      cliAppCreation(createCliApp _, gen)
+
+    }
+  )
 
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -21,12 +21,6 @@ sealed trait CliApp[-R, +E, +A] { self =>
 
   def config(newConfig: CliConfig): CliApp[R, E, A]
 
-  /* def clean: CliApp[Any, Nothing, Unit] =
-    self match {
-      case CliApp.CliAppImpl(name, version, summary, command, execute, footer, config, figFont) =>
-        CliApp.CliAppImpl(name, version, summary, command, _ => ZIO.unit, footer, config, figFont)
-    }*/
-
   final def map[B](f: A => B): CliApp[R, E, B] =
     self match {
       case CliApp.CliAppImpl(name, version, summary, command, execute, footer, config, figFont) =>

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -15,19 +15,35 @@ import scala.annotation.tailrec
  * A `CliApp[R, E]` is a complete description of a command-line application, which requires environment `R`, and may
  * fail with a value of type `E`.
  */
-sealed trait CliApp[-R, +E, +Model] {
-  def run(args: List[String]): ZIO[R, Any, Any]
+sealed trait CliApp[-R, +E, +A] { self =>
 
-  def config(newConfig: CliConfig): CliApp[R, E, Model]
+  def run(args: List[String]): ZIO[R, CliError[E], Option[A]]
 
-  def footer(newFooter: HelpDoc): CliApp[R, E, Model]
+  def config(newConfig: CliConfig): CliApp[R, E, A]
 
-  def summary(s: HelpDoc.Span): CliApp[R, E, Model]
+ /* def clean: CliApp[Any, Nothing, Unit] =
+    self match {
+      case CliApp.CliAppImpl(name, version, summary, command, execute, footer, config, figFont) =>
+        CliApp.CliAppImpl(name, version, summary, command, _ => ZIO.unit, footer, config, figFont)
+    }*/
+
+  final def map[B](f: A => B): CliApp[R, E, B] =
+    self match {
+      case CliApp.CliAppImpl(name, version, summary, command, execute, footer, config, figFont) =>
+        CliApp.CliAppImpl(name, version, summary, command, execute.andThen(_.map(f)), footer, config, figFont)
+    }
+
+  def flatMap[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): CliApp[R1, E1, B]
+
+  def footer(newFooter: HelpDoc): CliApp[R, E, A]
+
+  def summary(s: HelpDoc.Span): CliApp[R, E, A]
+
 }
 
 object CliApp {
 
-  def make[R, E, Model](
+  def make[R, E, Model, A](
     name: String,
     version: String,
     summary: HelpDoc.Span,
@@ -35,29 +51,29 @@ object CliApp {
     footer: HelpDoc = HelpDoc.Empty,
     config: CliConfig = CliConfig.default,
     figFont: FigFont = FigFont.Default
-  )(execute: Model => ZIO[R, E, Any]): CliApp[R, E, Model] =
+  )(execute: Model => ZIO[R, E, A]): CliApp[R, E, A] =
     CliAppImpl(name, version, summary, command, execute, footer, config, figFont)
 
-  private case class CliAppImpl[-R, +E, Model](
+  private[cli] case class CliAppImpl[-R, +E, Model, +A](
     name: String,
     version: String,
     summary: HelpDoc.Span,
     command: Command[Model],
-    execute: Model => ZIO[R, E, Any],
+    execute: Model => ZIO[R, E, A],
     footer: HelpDoc = HelpDoc.Empty,
     config: CliConfig = CliConfig.default,
     figFont: FigFont = FigFont.Default
-  ) extends CliApp[R, E, Model] { self =>
-    def config(newConfig: CliConfig): CliApp[R, E, Model] = copy(config = newConfig)
+  ) extends CliApp[R, E, A] { self =>
+    def config(newConfig: CliConfig): CliApp[R, E, A] = copy(config = newConfig)
 
-    def footer(newFooter: HelpDoc): CliApp[R, E, Model] =
+    def footer(newFooter: HelpDoc): CliApp[R, E, A] =
       copy(footer = self.footer + newFooter)
 
     def printDocs(helpDoc: HelpDoc): UIO[Unit] =
       printLine(helpDoc.toPlaintext(80)).!
 
-    def run(args: List[String]): ZIO[R, Any, Any] = {
-      def executeBuiltIn(builtInOption: BuiltInOption): ZIO[R, Any, Any] =
+    def run(args: List[String]): ZIO[R, CliError[E], Option[A]] = {
+      def executeBuiltIn(builtInOption: BuiltInOption): ZIO[R, CliError[E], Option[A]] =
         builtInOption match {
           case ShowHelp(synopsis, helpDoc) =>
             val fancyName = p(code(self.figFont.render(self.name)))
@@ -71,12 +87,14 @@ object CliApp {
               .foldRight(HelpDoc.empty)(_ + _)
 
             // TODO add rendering of built-in options such as help
-            printLine((fancyName + header + synopsisHelpDoc + helpDoc + self.footer).toPlaintext(columnWidth = 300))
+            printLine(
+              (fancyName + header + synopsisHelpDoc + helpDoc + self.footer).toPlaintext(columnWidth = 300)
+              ).map(_ => None).mapError(CliError.IO(_))
 
           case ShowCompletionScript(path, shellType) =>
             printLine(
               CompletionScript(path, if (self.command.names.nonEmpty) self.command.names else Set(self.name), shellType)
-            )
+            ).map(_ => None).mapError(CliError.IO(_))
           case ShowCompletions(index, _) =>
             envs.flatMap { envMap =>
               val compWords = envMap.collect {
@@ -89,17 +107,17 @@ object CliApp {
                 .flatMap { completions =>
                   ZIO.foreachDiscard(completions)(word => printLine(word))
                 }
-            }
+            }.map(_ => None).mapError(CliError.BuiltIn(_))
           case ShowWizard(command) => {
             val fancyName   = p(code(self.figFont.render(self.name)))
             val header      = p(text("WIZARD of ") + text(self.name) + text(self.version) + text(" -- ") + self.summary)
             val explanation = p(s"Wizard mode assist you in constructing commands for $name$version")
 
             (for {
-              parameters <- Wizard(command, config, fancyName + header + explanation).execute
-              _          <- run(parameters)
-            } yield ()).catchSome { case Wizard.QuitException() =>
-              ZIO.unit
+              parameters <- Wizard(command, config, fancyName + header + explanation).execute.mapError(CliError.BuiltIn(_))
+              output     <- run(parameters)
+            } yield output).catchSome { case CliError.BuiltIn(_) =>
+              ZIO.succeed(None)
             }
           }
 
@@ -118,18 +136,31 @@ object CliApp {
       self.command
         .parse(prefix(self.command) ++ args, self.config)
         .foldZIO(
-          e => printDocs(e.error) *> ZIO.fail(e),
+          e => printDocs(e.error) *> ZIO.fail(CliError.Parsing(e)),
           {
-            case CommandDirective.UserDefined(_, value) => self.execute(value)
+            case CommandDirective.UserDefined(_, value) => 
+              self.execute(value).map(Some(_)).mapError(CliError.Execution(_))
             case CommandDirective.BuiltIn(x) =>
-              executeBuiltIn(x).catchSome { case e: ValidationError =>
-                printDocs(e.error) *> ZIO.fail(e)
+              executeBuiltIn(x).catchSome { case err@CliError.Parsing(e) =>
+                printDocs(e.error) *> ZIO.fail(err)
               }
           }
         )
     }
 
-    def summary(s: HelpDoc.Span): CliApp[R, E, Model] =
+    override def flatMap[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): CliApp[R1, E1, B] =
+      CliAppImpl[R1, E1, Model, B](
+        name, 
+        version, 
+        summary,
+        command,
+        {app: ZIO[R, E, A] => app.flatMap(f)} compose execute,
+        footer,
+        config,
+        figFont
+      )
+
+    override def summary(s: HelpDoc.Span): CliApp[R, E, A] =
       copy(summary = self.summary + s)
   }
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/CliError.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliError.scala
@@ -1,0 +1,17 @@
+package zio.cli
+
+import java.io.IOException
+
+sealed trait CliError[+E] extends Exception
+
+object CliError {
+
+    case class BuiltIn(e: Exception) extends CliError[Nothing]
+
+    case class IO(e: IOException) extends CliError[Nothing]
+
+    case class Parsing(e: ValidationError) extends CliError[Nothing]
+
+    case class Execution[+E](e: E) extends CliError[E]
+
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/CliError.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliError.scala
@@ -6,12 +6,12 @@ sealed trait CliError[+E] extends Exception
 
 object CliError {
 
-    case class BuiltIn(e: Exception) extends CliError[Nothing]
+  case class BuiltIn(e: Exception) extends CliError[Nothing]
 
-    case class IO(e: IOException) extends CliError[Nothing]
+  case class IO(e: IOException) extends CliError[Nothing]
 
-    case class Parsing(e: ValidationError) extends CliError[Nothing]
+  case class Parsing(e: ValidationError) extends CliError[Nothing]
 
-    case class Execution[+E](e: E) extends CliError[E]
+  case class Execution[+E](e: E) extends CliError[E]
 
 }

--- a/zio-cli/shared/src/main/scala/zio/cli/ZIOCli.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/ZIOCli.scala
@@ -9,7 +9,7 @@ trait ZIOCli extends ZIOApp {
   override def run =
     for {
       args <- ZIOAppArgs.getArgs
-      result <- cliApp.run(args.toList).catchSome { case _: ValidationError =>
+      result <- cliApp.run(args.toList).catchSome { case CliError.Parsing(_) =>
                   // Validation errors are pretty printed by clipApp.run
                   exit(ExitCode.failure)
                 }

--- a/zio-cli/shared/src/test/scala/zio/cli/ArgumentCollisionSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/ArgumentCollisionSpec.scala
@@ -2,6 +2,7 @@ package zio.cli
 
 import zio._
 import zio.test._
+import java.io.IOException
 
 object ArgumentCollisionSpec extends ZIOSpecDefault {
   def spec = suite("ArgumentCollisionSpec")(
@@ -9,7 +10,7 @@ object ArgumentCollisionSpec extends ZIOSpecDefault {
       val a = Options.text("a").map(identity)
       val b = Options.text("b").map(identity)
 
-      val argumentCollisionApp: CliApp[Any, Nothing, String] =
+      val argumentCollisionApp: CliApp[Any, IOException, Unit] =
         CliApp.make(
           "test",
           "0.1.0",

--- a/zio-cli/shared/src/test/scala/zio/cli/CliAppSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CliAppSpec.scala
@@ -20,7 +20,7 @@ object CliAppSpec extends ZIOSpecDefault {
 
     val exampleCmd: Command[Subcommand] = Command("example").subcommands(makeCmd)
 
-    def app(behavior: Task[Unit] = ZIO.unit) = CliApp.make(
+    def app(behavior: Task[Unit] = ZIO.unit): CliApp[Any, Throwable, Unit] = CliApp.make(
       name = "Grumpy",
       version = "0.0.1",
       summary = HelpDoc.Span.text("this is some doc"),


### PR DESCRIPTION
I think that the intended type of `CliApp` and its methods was mistaken when `CliAppImpl` was encapsulated. Now, instead of returning a `ZIO[R, Any, Any]` when running a command, it returns `ZIO[R, E, A]` for a `CliApp[R, E, A]`. This way, the `Model` type of the `Command` is really encapsulated. In particular this allows to implement `map` and `flatMap` methods. This is used later in the testkit.

The testkit is fairly complete for most purposes, but it might benefit from further work, mainly if some particular use-case arise. It includes also methods for testing functions that return a `CliApp` or a `Command`, that is the use-case of ZIO HTTP, for example.
/claim #256