### PR TITLE
Add a space between app name and version

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -72,7 +72,7 @@ object CliApp {
           case ShowHelp(synopsis, helpDoc) =>
             val fancyName = p(code(self.figFont.render(self.name)))
 
-            val header = p(text(self.name) + text(self.version) + text(" -- ") + self.summary)
+            val header = p(text(self.name) + text(" ") + text(self.version) + text(" -- ") + self.summary)
 
             val synopsisHelpDoc = h1("usage") + synopsis
               .enumerate(config)


### PR DESCRIPTION
I appreciate removing `v` in 669bd1dbe0ad3c2c1503c2fdc62520b1837ea1bd but I think having a space between the name and version is a good default.