### PR TITLE
feat: add dotfile-based configuration system (#191)

### DIFF
--- a/zio-cli/js/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -1,0 +1,13 @@
+package zio.cli.config
+
+import zio._
+
+/**
+ * JS implementation of config file resolution — no-op stub.
+ * ScalaJS does not support `java.nio.file`, so dotfile config is unavailable.
+ */
+trait ConfigFileResolverPlatformSpecific {
+
+  def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
+    ZIO.succeed(Nil)
+}

--- a/zio-cli/js/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/js/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -3,11 +3,13 @@ package zio.cli.config
 import zio._
 
 /**
- * JS implementation of config file resolution — no-op stub.
- * ScalaJS does not support `java.nio.file`, so dotfile config is unavailable.
+ * JS implementation of config file resolution — no-op stub. ScalaJS does not support `java.nio.file`, so dotfile config
+ * is unavailable.
  */
 trait ConfigFileResolverPlatformSpecific {
 
-  def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
+  def resolveAndParse(commandName: String): Task[List[ConfigOption]] = {
+    val _ = commandName
     ZIO.succeed(Nil)
+  }
 }

--- a/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -1,7 +1,7 @@
 package zio.cli.config
 
 import zio._
-import java.nio.file.{Files, Path, Paths}
+import java.io.File
 import scala.io.Source
 
 /**
@@ -17,30 +17,30 @@ trait ConfigFileResolverPlatformSpecific {
   def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
     ZIO.attempt {
       val fileName = s".$commandName"
-      val homePath = sys.props.get("user.home").map(Paths.get(_)).map(_.resolve(fileName))
-      val cwd      = Paths.get("").toAbsolutePath
+      val homePath = sys.props.get("user.home").map(new File(_, fileName))
+      val cwd      = new File("").getAbsoluteFile
 
-      def getParents(path: Path): List[Path] = {
-        val parent = path.getParent
-        if (parent == null) List(path) else path :: getParents(parent)
+      def getParents(file: File): List[File] = {
+        val parent = file.getParentFile
+        if (parent == null) List(file) else file :: getParents(parent)
       }
 
       // From root to CWD
       val cwdUpToRoot = getParents(cwd).reverse
-      val cwdPaths    = cwdUpToRoot.map(_.resolve(fileName))
+      val cwdPaths    = cwdUpToRoot.map(dir => new File(dir, fileName))
 
       // home first (lowest priority), then root→cwd
       val allPaths = homePath.toList ++ cwdPaths
 
       // De-duplicate, keep only existing files, and assign priority indices
-      val existing = allPaths.distinct.filter(Files.exists(_))
+      val existing = allPaths.distinct.filter(_.exists())
 
-      existing.zipWithIndex.flatMap { case (path, priority) =>
-        val source = Source.fromFile(path.toFile, "UTF-8")
+      existing.zipWithIndex.flatMap { case (file, priority) =>
+        val source = Source.fromFile(file, "UTF-8")
         val lines  =
           try source.getLines().toList
           finally source.close()
-        ConfigParser.parseLines(lines, path.toString, priority)
+        ConfigParser.parseLines(lines, file.getAbsolutePath, priority)
       }
     }
 }

--- a/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -5,14 +5,14 @@ import java.nio.file.{Files, Path, Paths}
 import scala.io.Source
 
 /**
- * JVM implementation of config file resolution.
- * Walks from CWD to root, then home, looking for `.<commandName>` dotfiles.
+ * JVM implementation of config file resolution. Walks from CWD to root, then home, looking for `.<commandName>`
+ * dotfiles.
  */
 trait ConfigFileResolverPlatformSpecific {
 
   /**
-   * Discovers config files and parses them into [[ConfigOption]] values.
-   * Priority order: home (lowest) → root → … → cwd (highest).
+   * Discovers config files and parses them into [[ConfigOption]] values. Priority order: home (lowest) → root → … → cwd
+   * (highest).
    */
   def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
     ZIO.attempt {
@@ -37,7 +37,9 @@ trait ConfigFileResolverPlatformSpecific {
 
       existing.zipWithIndex.flatMap { case (path, priority) =>
         val source = Source.fromFile(path.toFile, "UTF-8")
-        val lines  = try source.getLines().toList finally source.close()
+        val lines  =
+          try source.getLines().toList
+          finally source.close()
         ConfigParser.parseLines(lines, path.toString, priority)
       }
     }

--- a/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/jvm/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -1,0 +1,44 @@
+package zio.cli.config
+
+import zio._
+import java.nio.file.{Files, Path, Paths}
+import scala.io.Source
+
+/**
+ * JVM implementation of config file resolution.
+ * Walks from CWD to root, then home, looking for `.<commandName>` dotfiles.
+ */
+trait ConfigFileResolverPlatformSpecific {
+
+  /**
+   * Discovers config files and parses them into [[ConfigOption]] values.
+   * Priority order: home (lowest) → root → … → cwd (highest).
+   */
+  def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
+    ZIO.attempt {
+      val fileName = s".$commandName"
+      val homePath = sys.props.get("user.home").map(Paths.get(_)).map(_.resolve(fileName))
+      val cwd      = Paths.get("").toAbsolutePath
+
+      def getParents(path: Path): List[Path] = {
+        val parent = path.getParent
+        if (parent == null) List(path) else path :: getParents(parent)
+      }
+
+      // From root to CWD
+      val cwdUpToRoot = getParents(cwd).reverse
+      val cwdPaths    = cwdUpToRoot.map(_.resolve(fileName))
+
+      // home first (lowest priority), then root→cwd
+      val allPaths = homePath.toList ++ cwdPaths
+
+      // De-duplicate, keep only existing files, and assign priority indices
+      val existing = allPaths.distinct.filter(Files.exists(_))
+
+      existing.zipWithIndex.flatMap { case (path, priority) =>
+        val source = Source.fromFile(path.toFile, "UTF-8")
+        val lines  = try source.getLines().toList finally source.close()
+        ConfigParser.parseLines(lines, path.toString, priority)
+      }
+    }
+}

--- a/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -1,36 +1,37 @@
 package zio.cli.config
 
 import zio._
-import java.nio.file.{Files, Path, Paths}
+import java.io.File
 import scala.io.Source
 
 /**
- * Native implementation of config file resolution. Identical to JVM — Scala Native supports `java.nio.file`.
+ * Native implementation of config file resolution. Uses java.io.File which is much more stable in Scala Native than
+ * java.nio.file.
  */
 trait ConfigFileResolverPlatformSpecific {
 
   def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
     ZIO.attempt {
       val fileName = s".$commandName"
-      val homePath = sys.props.get("user.home").map(Paths.get(_)).map(_.resolve(fileName))
-      val cwd      = Paths.get("").toAbsolutePath
+      val homePath = sys.props.get("user.home").map(new File(_, fileName))
+      val cwd      = new File("").getAbsoluteFile
 
-      def getParents(path: Path): List[Path] = {
-        val parent = path.getParent
-        if (parent == null) List(path) else path :: getParents(parent)
+      def getParents(file: File): List[File] = {
+        val parent = file.getParentFile
+        if (parent == null) List(file) else file :: getParents(parent)
       }
 
       val cwdUpToRoot = getParents(cwd).reverse
-      val cwdPaths    = cwdUpToRoot.map(_.resolve(fileName))
+      val cwdPaths    = cwdUpToRoot.map(dir => new File(dir, fileName))
       val allPaths    = homePath.toList ++ cwdPaths
-      val existing    = allPaths.distinct.filter(Files.exists(_))
+      val existing    = allPaths.distinct.filter(_.exists())
 
-      existing.zipWithIndex.flatMap { case (path, priority) =>
-        val source = Source.fromFile(path.toFile, "UTF-8")
+      existing.zipWithIndex.flatMap { case (file, priority) =>
+        val source = Source.fromFile(file, "UTF-8")
         val lines  =
           try source.getLines().toList
           finally source.close()
-        ConfigParser.parseLines(lines, path.toString, priority)
+        ConfigParser.parseLines(lines, file.getAbsolutePath, priority)
       }
     }
 }

--- a/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -1,0 +1,35 @@
+package zio.cli.config
+
+import zio._
+import java.nio.file.{Files, Path, Paths}
+import scala.io.Source
+
+/**
+ * Native implementation of config file resolution.
+ * Identical to JVM — Scala Native supports `java.nio.file`.
+ */
+trait ConfigFileResolverPlatformSpecific {
+
+  def resolveAndParse(commandName: String): Task[List[ConfigOption]] =
+    ZIO.attempt {
+      val fileName = s".$commandName"
+      val homePath = sys.props.get("user.home").map(Paths.get(_)).map(_.resolve(fileName))
+      val cwd      = Paths.get("").toAbsolutePath
+
+      def getParents(path: Path): List[Path] = {
+        val parent = path.getParent
+        if (parent == null) List(path) else path :: getParents(parent)
+      }
+
+      val cwdUpToRoot = getParents(cwd).reverse
+      val cwdPaths    = cwdUpToRoot.map(_.resolve(fileName))
+      val allPaths    = homePath.toList ++ cwdPaths
+      val existing    = allPaths.distinct.filter(Files.exists(_))
+
+      existing.zipWithIndex.flatMap { case (path, priority) =>
+        val source = Source.fromFile(path.toFile, "UTF-8")
+        val lines  = try source.getLines().toList finally source.close()
+        ConfigParser.parseLines(lines, path.toString, priority)
+      }
+    }
+}

--- a/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
+++ b/zio-cli/native/src/main/scala/zio/cli/config/ConfigFileResolverPlatformSpecific.scala
@@ -5,8 +5,7 @@ import java.nio.file.{Files, Path, Paths}
 import scala.io.Source
 
 /**
- * Native implementation of config file resolution.
- * Identical to JVM — Scala Native supports `java.nio.file`.
+ * Native implementation of config file resolution. Identical to JVM — Scala Native supports `java.nio.file`.
  */
 trait ConfigFileResolverPlatformSpecific {
 
@@ -28,7 +27,9 @@ trait ConfigFileResolverPlatformSpecific {
 
       existing.zipWithIndex.flatMap { case (path, priority) =>
         val source = Source.fromFile(path.toFile, "UTF-8")
-        val lines  = try source.getLines().toList finally source.close()
+        val lines  =
+          try source.getLines().toList
+          finally source.close()
         ConfigParser.parseLines(lines, path.toString, priority)
       }
     }

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -8,6 +8,7 @@ import zio.cli.HelpDoc.Span.{code, text}
 import zio.cli.HelpDoc.{h1, p}
 import zio.cli.completion.{Completion, CompletionScript}
 import zio.cli.figlet.FigFont
+import zio.cli.config._
 
 import scala.annotation.tailrec
 
@@ -80,9 +81,14 @@ object CliApp {
               .map(HelpDoc.p)
               .foldRight(HelpDoc.empty)(_ + _)
 
+            val configHelp = h1("configuration") +
+              p(s"This application supports configuration via dotfiles. You can create a file named .${self.name} to define your options. Format is either `--key=value`, `--key value`, or `--flag` per line.") +
+              p("Priority (Highest to Lowest): CLI arguments > Current Directory > Parent Directories > Home Directory.") +
+              p("Use the --config-diagnostics flag to preview how configuration is being resolved.")
+
             // TODO add rendering of built-in options such as help
             printLine(
-              (fancyName + header + synopsisHelpDoc + helpDoc + self.footer).toPlaintext(columnWidth = 300)
+              (fancyName + header + synopsisHelpDoc + helpDoc + configHelp + self.footer).toPlaintext(columnWidth = 300)
             ).mapBoth(CliError.IO(_), _ => None)
           case ShowCompletionScript(path, shellType) =>
             printLine(
@@ -125,19 +131,30 @@ object CliApp {
           case Command.Subcommands(parent, _) => prefix(parent)
         }
 
-      self.command
-        .parse(prefix(self.command) ++ args, self.config)
-        .foldZIO(
-          e => printDocs(e.error) *> ZIO.fail(CliError.Parsing(e)),
-          {
-            case CommandDirective.UserDefined(_, value) =>
-              self.execute(value).mapBoth(CliError.Execution(_), Some(_))
-            case CommandDirective.BuiltIn(x) =>
-              executeBuiltIn(x).catchSome { case err @ CliError.Parsing(e) =>
-                printDocs(e.error) *> ZIO.fail(err)
-              }
-          }
-        )
+      val configEffect = for {
+        configOpts <- ConfigFileResolver.resolveAndParse(self.name).catchAll(_ => ZIO.succeed(Nil))
+        (mergedArgs, diagnostics) = ConfigMerger.mergeWithDiagnostics(configOpts, args)
+        _ <- ConfigDiagnostics.printDiagnostics(diagnostics).when(args.contains("--config-diagnostics"))
+
+        isBuiltIn = args.exists(h => h == "--help" || h == "-h" || h == "--wizard" || h == "--compgen" || h == "--generate-completion")
+        finalArgs = if (isBuiltIn) args else mergedArgs.filterNot(_ == "--config-diagnostics")
+      } yield finalArgs
+
+      configEffect.flatMap { finalArgs =>
+        self.command
+          .parse(prefix(self.command) ++ finalArgs, self.config)
+          .foldZIO(
+            e => printDocs(e.error) *> ZIO.fail(CliError.Parsing(e)),
+            {
+              case CommandDirective.UserDefined(_, value) =>
+                self.execute(value).mapBoth(CliError.Execution(_), Some(_))
+              case CommandDirective.BuiltIn(x) =>
+                executeBuiltIn(x).catchSome { case err @ CliError.Parsing(e) =>
+                  printDocs(e.error) *> ZIO.fail(err)
+                }
+            }
+          )
+      }
     }
 
     override def flatMap[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): CliApp[R1, E1, B] =

--- a/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/CliApp.scala
@@ -82,8 +82,12 @@ object CliApp {
               .foldRight(HelpDoc.empty)(_ + _)
 
             val configHelp = h1("configuration") +
-              p(s"This application supports configuration via dotfiles. You can create a file named .${self.name} to define your options. Format is either `--key=value`, `--key value`, or `--flag` per line.") +
-              p("Priority (Highest to Lowest): CLI arguments > Current Directory > Parent Directories > Home Directory.") +
+              p(
+                s"This application supports configuration via dotfiles. You can create a file named .${self.name} to define your options. Format is either `--key=value`, `--key value`, or `--flag` per line."
+              ) +
+              p(
+                "Priority (Highest to Lowest): CLI arguments > Current Directory > Parent Directories > Home Directory."
+              ) +
               p("Use the --config-diagnostics flag to preview how configuration is being resolved.")
 
             // TODO add rendering of built-in options such as help
@@ -132,11 +136,13 @@ object CliApp {
         }
 
       val configEffect = for {
-        configOpts <- ConfigFileResolver.resolveAndParse(self.name).catchAll(_ => ZIO.succeed(Nil))
+        configOpts               <- ConfigFileResolver.resolveAndParse(self.name).catchAll(_ => ZIO.succeed(Nil))
         (mergedArgs, diagnostics) = ConfigMerger.mergeWithDiagnostics(configOpts, args)
-        _ <- ConfigDiagnostics.printDiagnostics(diagnostics).when(args.contains("--config-diagnostics"))
+        _                        <- ConfigDiagnostics.printDiagnostics(diagnostics).when(args.contains("--config-diagnostics"))
 
-        isBuiltIn = args.exists(h => h == "--help" || h == "-h" || h == "--wizard" || h == "--compgen" || h == "--generate-completion")
+        isBuiltIn = args.exists(h =>
+                      h == "--help" || h == "-h" || h == "--wizard" || h == "--compgen" || h == "--generate-completion"
+                    )
         finalArgs = if (isBuiltIn) args else mergedArgs.filterNot(_ == "--config-diagnostics")
       } yield finalArgs
 

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigDiagnostics.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigDiagnostics.scala
@@ -24,8 +24,8 @@ case class ConfigConflict(
 object ConfigDiagnostics {
 
   /**
-   * Prints a human-readable summary of where each resolved option came from,
-   * which options were overridden by CLI, and detected conflicts.
+   * Prints a human-readable summary of where each resolved option came from, which options were overridden by CLI, and
+   * detected conflicts.
    */
   def printDiagnostics(diagnostics: ConfigDiagnostics): UIO[Unit] = {
     val header = Console.printLine("\n--- Config Diagnostics ---").ignore

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigDiagnostics.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigDiagnostics.scala
@@ -1,0 +1,63 @@
+package zio.cli.config
+
+import zio._
+
+/**
+ * Diagnostic information about how configuration was resolved.
+ */
+case class ConfigDiagnostics(
+  resolvedOptions: List[ConfigOption],
+  conflicts: List[ConfigConflict],
+  cliOverrides: List[String]
+)
+
+/**
+ * Records when the same key appears in multiple config sources.
+ */
+case class ConfigConflict(
+  key: String,
+  overridden: List[ConfigOption],
+  winner: Option[ConfigOption],
+  cliOverride: Boolean
+)
+
+object ConfigDiagnostics {
+
+  /**
+   * Prints a human-readable summary of where each resolved option came from,
+   * which options were overridden by CLI, and detected conflicts.
+   */
+  def printDiagnostics(diagnostics: ConfigDiagnostics): UIO[Unit] = {
+    val header = Console.printLine("\n--- Config Diagnostics ---").ignore
+
+    val printResolved = ZIO.foreachDiscard(diagnostics.resolvedOptions) { opt =>
+      val valueStr = opt.value.getOrElse("<flag>")
+      Console.printLine(s"  ${opt.key.stripPrefix("-")} = $valueStr   (from ${opt.source})").ignore
+    }
+
+    val printCli = ZIO.foreachDiscard(diagnostics.cliOverrides) { key =>
+      Console.printLine(s"  ${key.stripPrefix("-")}   (overridden by CLI)").ignore
+    }
+
+    val printConflicts = ZIO.foreachDiscard(diagnostics.conflicts) { conflict =>
+      Console.printLine(s"  ⚠ Option '${conflict.key.stripPrefix("-")}' overridden:").ignore *>
+        ZIO.foreachDiscard(conflict.overridden) { opt =>
+          val valueStr = opt.value.getOrElse("<flag>")
+          Console.printLine(s"    ${opt.source} → $valueStr").ignore
+        } *>
+        (if (conflict.cliOverride)
+           Console.printLine(s"    (CLI wins)").ignore
+         else
+           conflict.winner match {
+             case Some(w) =>
+               val v = w.value.getOrElse("<flag>")
+               Console.printLine(s"    Winner: ${w.source} → $v").ignore
+             case None => ZIO.unit
+           })
+    }
+
+    val footer = Console.printLine("--- End Diagnostics ---\n").ignore
+
+    header *> printResolved *> printCli *> printConflicts *> footer
+  }
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigFileResolver.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigFileResolver.scala
@@ -1,0 +1,13 @@
+package zio.cli.config
+
+/**
+ * Resolves dotfile-based configuration files for a CLI command.
+ *
+ * Searches for `.<commandName>` files in the following order (lowest to highest priority):
+ *   1. Home directory
+ *   2. Root directory → ... → parent directories
+ *   3. Current working directory (highest priority)
+ *
+ * Platform-specific: JVM/Native use `java.nio.file`, JS returns empty.
+ */
+object ConfigFileResolver extends ConfigFileResolverPlatformSpecific

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigMerger.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigMerger.scala
@@ -1,0 +1,77 @@
+package zio.cli.config
+
+/**
+ * Merges config file options with CLI arguments.
+ *
+ * Rules:
+ *   1. CLI arguments always override file-based options.
+ *   2. Higher-priority files (closer to cwd) override lower-priority files.
+ *   3. No duplicate keys in the final output.
+ */
+object ConfigMerger {
+
+  def merge(
+    fileOptions: List[ConfigOption],
+    cliArgs: List[String]
+  ): List[String] = mergeWithDiagnostics(fileOptions, cliArgs)._1
+
+  def mergeWithDiagnostics(
+    fileOptions: List[ConfigOption],
+    cliArgs: List[String]
+  ): (List[String], ConfigDiagnostics) = {
+
+    // Identify keys provided in CLI arguments
+    val cliKeysMap = cliArgs.flatMap { arg =>
+      val eqIdx = arg.indexOf('=')
+      if (eqIdx > 0 && arg.startsWith("-")) Some(arg.substring(0, eqIdx) -> arg)
+      else if (arg.startsWith("-"))          Some(arg -> arg)
+      else                                   None
+    }.toMap
+
+    val cliKeys = cliKeysMap.keySet
+
+    // Group file options by key
+    val groupedOptions = fileOptions.groupBy(_.key)
+
+    var resolvedOptionsList = List.empty[ConfigOption]
+    var conflictsList       = List.empty[ConfigConflict]
+    var cliOverridesList    = List.empty[String]
+
+    groupedOptions.foreach { case (key, options) =>
+      val sortedOpts        = options.sortBy(_.priority)
+      val isOverriddenByCli = cliKeys.contains(key)
+
+      if (isOverriddenByCli) {
+        cliOverridesList = key :: cliOverridesList
+        if (sortedOpts.nonEmpty)
+          conflictsList = ConfigConflict(key, sortedOpts, None, cliOverride = true) :: conflictsList
+      } else {
+        val winner = sortedOpts.last
+        resolvedOptionsList = winner :: resolvedOptionsList
+
+        if (sortedOpts.size > 1)
+          conflictsList = ConfigConflict(
+            key,
+            sortedOpts.init,
+            Some(winner),
+            cliOverride = false
+          ) :: conflictsList
+      }
+    }
+
+    val diagnostics = ConfigDiagnostics(
+      resolvedOptionsList.reverse,
+      conflictsList.reverse,
+      cliOverridesList.reverse
+    )
+
+    val fileArgs = resolvedOptionsList.reverse.flatMap { opt =>
+      opt.value match {
+        case Some(v) => List(s"${opt.key}=$v")
+        case None    => List(opt.key)
+      }
+    }
+
+    (fileArgs ++ cliArgs, diagnostics)
+  }
+}

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigMerger.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigMerger.scala
@@ -24,8 +24,8 @@ object ConfigMerger {
     val cliKeysMap = cliArgs.flatMap { arg =>
       val eqIdx = arg.indexOf('=')
       if (eqIdx > 0 && arg.startsWith("-")) Some(arg.substring(0, eqIdx) -> arg)
-      else if (arg.startsWith("-"))          Some(arg -> arg)
-      else                                   None
+      else if (arg.startsWith("-")) Some(arg -> arg)
+      else None
     }.toMap
 
     val cliKeys = cliKeysMap.keySet

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigParser.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigParser.scala
@@ -3,10 +3,14 @@ package zio.cli.config
 /**
  * Represents a single configuration option parsed from a dotfile.
  *
- * @param key      The option key, including dashes (e.g. "--max-lines")
- * @param value    Optional value for the option
- * @param source   File path string where the option was found
- * @param priority Priority index (higher = more important, closer to cwd)
+ * @param key
+ *   The option key, including dashes (e.g. "--max-lines")
+ * @param value
+ *   Optional value for the option
+ * @param source
+ *   File path string where the option was found
+ * @param priority
+ *   Priority index (higher = more important, closer to cwd)
  */
 case class ConfigOption(
   key: String,

--- a/zio-cli/shared/src/main/scala/zio/cli/config/ConfigParser.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/config/ConfigParser.scala
@@ -1,0 +1,46 @@
+package zio.cli.config
+
+/**
+ * Represents a single configuration option parsed from a dotfile.
+ *
+ * @param key      The option key, including dashes (e.g. "--max-lines")
+ * @param value    Optional value for the option
+ * @param source   File path string where the option was found
+ * @param priority Priority index (higher = more important, closer to cwd)
+ */
+case class ConfigOption(
+  key: String,
+  value: Option[String],
+  source: String,
+  priority: Int
+)
+
+/**
+ * Parses dotfile lines into structured [[ConfigOption]] values.
+ *
+ * Supported formats per line:
+ *   - `--key=value`
+ *   - `--flag`
+ *   - Lines starting with `#` are treated as comments
+ *   - Empty lines are ignored
+ */
+object ConfigParser {
+
+  def parseLines(lines: List[String], source: String, priority: Int): List[ConfigOption] =
+    lines
+      .map(_.trim)
+      .filterNot(l => l.isEmpty || l.startsWith("#"))
+      .flatMap(line => parseLine(line, source, priority))
+
+  private[config] def parseLine(line: String, source: String, priority: Int): Option[ConfigOption] =
+    if (line.startsWith("-")) {
+      val eqIdx = line.indexOf('=')
+      if (eqIdx > 0) {
+        val key   = line.substring(0, eqIdx).trim
+        val value = line.substring(eqIdx + 1).trim
+        Some(ConfigOption(key, Some(value), source, priority))
+      } else {
+        Some(ConfigOption(line.trim, None, source, priority))
+      }
+    } else None
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/config/ConfigEngineSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/config/ConfigEngineSpec.scala
@@ -1,0 +1,136 @@
+package zio.cli.config
+
+import zio.test._
+import zio.test.Assertion._
+
+object ConfigEngineSpec extends ZIOSpecDefault {
+
+  def spec = suite("ConfigEngineSpec")(
+    suite("ConfigFileResolver")(
+      test("1. resolves without error on a nonexistent command") {
+        for {
+          opts <- ConfigFileResolver.resolveAndParse("nonexistent_xyz_test")
+        } yield assert(opts)(isEmpty)
+      },
+      test("2. resolves without error when command name is valid") {
+        for {
+          opts <- ConfigFileResolver.resolveAndParse("testcli_check")
+        } yield assert(opts)(isEmpty)
+      }
+    ),
+    suite("ConfigParser")(
+      test("3. parses --key=value correctly") {
+        val parsed = ConfigParser.parseLine("--max-lines=100", "/path/.wc", 1)
+        assert(parsed)(isSome(equalTo(ConfigOption("--max-lines", Some("100"), "/path/.wc", 1))))
+      },
+      test("4. parses --flag correctly") {
+        val parsed = ConfigParser.parseLine("--verbose", "/path/.wc", 2)
+        assert(parsed)(isSome(equalTo(ConfigOption("--verbose", None, "/path/.wc", 2))))
+      },
+      test("5. ignores invalid lines without dashes") {
+        val parsed = ConfigParser.parseLine("invalid-line-without-dash", "/src", 1)
+        assert(parsed)(isNone)
+      },
+      test("6. ignores empty lines") {
+        val parsed = ConfigParser.parseLine("", "/src", 1)
+        assert(parsed)(isNone)
+      },
+      test("7. handles trailing spaces on flags") {
+        val parsed = ConfigParser.parseLine("--flag  ", "/src", 1)
+        assert(parsed)(isSome(equalTo(ConfigOption("--flag", None, "/src", 1))))
+      },
+      test("8. ignores comment lines") {
+        val lines = List("# this is a comment", "--flag", "# another comment")
+        val opts  = ConfigParser.parseLines(lines, "/src", 0)
+        assert(opts.length)(equalTo(1)) &&
+        assert(opts.head.key)(equalTo("--flag"))
+      },
+      test("9. parses multiple lines correctly") {
+        val lines = List("--a=1", "--b", "--c=hello")
+        val opts  = ConfigParser.parseLines(lines, "/src", 0)
+        assert(opts.length)(equalTo(3))
+      },
+      test("10. parses short flags") {
+        val parsed = ConfigParser.parseLine("-v", "/src", 0)
+        assert(parsed)(isSome(equalTo(ConfigOption("-v", None, "/src", 0))))
+      }
+    ),
+    suite("ConfigMerger")(
+      test("11. CLI args override file options") {
+        val fileOpts = List(ConfigOption("--max", Some("10"), "a", 1))
+        val cliArgs  = List("--max=20")
+        val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, cliArgs)
+        assert(merged)(equalTo(List("--max=20"))) &&
+        assert(diag.cliOverrides)(contains("--max"))
+      },
+      test("12. handles separated CLI overrides") {
+        val fileOpts = List(ConfigOption("--max", Some("10"), "a", 1))
+        val cliArgs  = List("--max", "20")
+        val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, cliArgs)
+        assert(merged)(equalTo(List("--max", "20"))) &&
+        assert(diag.cliOverrides)(contains("--max"))
+      },
+      test("13. higher priority file overrides lower") {
+        val fileOpts = List(
+          ConfigOption("--max", Some("10"), "lower", 1),
+          ConfigOption("--max", Some("50"), "higher", 2)
+        )
+        val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List.empty[String])
+        assert(merged)(equalTo(List("--max=50"))) &&
+        assert(diag.conflicts.head.winner.get.priority)(equalTo(2))
+      },
+      test("14. removes duplicate flags across files") {
+        val fileOpts = List(
+          ConfigOption("--flag", None, "1", 1),
+          ConfigOption("--flag", None, "2", 2),
+          ConfigOption("--flag", None, "3", 3)
+        )
+        val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List.empty)
+        assert(merged)(equalTo(List("--flag"))) &&
+        assert(diag.conflicts.head.overridden.length)(equalTo(2))
+      },
+      test("15. merges disjoint keys properly") {
+        val fileOpts = List(
+          ConfigOption("--a", Some("1"), "1", 1),
+          ConfigOption("--b", Some("2"), "2", 2)
+        )
+        val (merged, _) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("--c", "3"))
+        assert(merged.toSet)(equalTo(Set("--a=1", "--b=2", "--c", "3")))
+      },
+      test("16. records cli overrides properly in diagnostics") {
+        val fileOpts = List(ConfigOption("-f", None, "1", 1))
+        val (_, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("-f"))
+        assert(diag.cliOverrides)(equalTo(List("-f"))) &&
+        assert(diag.conflicts.head.cliOverride)(isTrue)
+      },
+      test("17. diagnostics resolvedOptions captured correctly") {
+        val fileOpts = List(
+          ConfigOption("-a", None, "1", 1),
+          ConfigOption("-b", None, "2", 2)
+        )
+        val (_, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List.empty)
+        assert(diag.resolvedOptions.map(_.key).toSet)(equalTo(Set("-a", "-b")))
+      },
+      test("18. merges key without value but cli has value") {
+        val fileOpts = List(ConfigOption("--k", None, "1", 1))
+        val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("--k=10"))
+        assert(merged)(equalTo(List("--k=10"))) &&
+        assert(diag.cliOverrides)(contains("--k"))
+      },
+      test("19. respects original cli args order") {
+        val fileOpts = List(ConfigOption("--fromFile", None, "1", 1))
+        val (merged, _) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("arg1", "arg2"))
+        assert(merged.takeRight(2))(equalTo(List("arg1", "arg2")))
+      },
+      test("20. does not falsely flag unique key as overridden") {
+        val fileOpts = List(ConfigOption("--x", Some("10"), "1", 1))
+        val (_, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("--y", "20"))
+        assert(diag.conflicts)(isEmpty)
+      },
+      test("21. empty file options means CLI args pass through unchanged") {
+        val (merged, _) = ConfigMerger.mergeWithDiagnostics(Nil, List("--a", "--b"))
+        assert(merged)(equalTo(List("--a", "--b")))
+      }
+    )
+  )
+}

--- a/zio-cli/shared/src/test/scala/zio/cli/config/ConfigEngineSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/config/ConfigEngineSpec.scala
@@ -57,15 +57,15 @@ object ConfigEngineSpec extends ZIOSpecDefault {
     ),
     suite("ConfigMerger")(
       test("11. CLI args override file options") {
-        val fileOpts = List(ConfigOption("--max", Some("10"), "a", 1))
-        val cliArgs  = List("--max=20")
+        val fileOpts       = List(ConfigOption("--max", Some("10"), "a", 1))
+        val cliArgs        = List("--max=20")
         val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, cliArgs)
         assert(merged)(equalTo(List("--max=20"))) &&
         assert(diag.cliOverrides)(contains("--max"))
       },
       test("12. handles separated CLI overrides") {
-        val fileOpts = List(ConfigOption("--max", Some("10"), "a", 1))
-        val cliArgs  = List("--max", "20")
+        val fileOpts       = List(ConfigOption("--max", Some("10"), "a", 1))
+        val cliArgs        = List("--max", "20")
         val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, cliArgs)
         assert(merged)(equalTo(List("--max", "20"))) &&
         assert(diag.cliOverrides)(contains("--max"))
@@ -98,7 +98,7 @@ object ConfigEngineSpec extends ZIOSpecDefault {
         assert(merged.toSet)(equalTo(Set("--a=1", "--b=2", "--c", "3")))
       },
       test("16. records cli overrides properly in diagnostics") {
-        val fileOpts = List(ConfigOption("-f", None, "1", 1))
+        val fileOpts  = List(ConfigOption("-f", None, "1", 1))
         val (_, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("-f"))
         assert(diag.cliOverrides)(equalTo(List("-f"))) &&
         assert(diag.conflicts.head.cliOverride)(isTrue)
@@ -112,18 +112,18 @@ object ConfigEngineSpec extends ZIOSpecDefault {
         assert(diag.resolvedOptions.map(_.key).toSet)(equalTo(Set("-a", "-b")))
       },
       test("18. merges key without value but cli has value") {
-        val fileOpts = List(ConfigOption("--k", None, "1", 1))
+        val fileOpts       = List(ConfigOption("--k", None, "1", 1))
         val (merged, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("--k=10"))
         assert(merged)(equalTo(List("--k=10"))) &&
         assert(diag.cliOverrides)(contains("--k"))
       },
       test("19. respects original cli args order") {
-        val fileOpts = List(ConfigOption("--fromFile", None, "1", 1))
+        val fileOpts    = List(ConfigOption("--fromFile", None, "1", 1))
         val (merged, _) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("arg1", "arg2"))
         assert(merged.takeRight(2))(equalTo(List("arg1", "arg2")))
       },
       test("20. does not falsely flag unique key as overridden") {
-        val fileOpts = List(ConfigOption("--x", Some("10"), "1", 1))
+        val fileOpts  = List(ConfigOption("--x", Some("10"), "1", 1))
         val (_, diag) = ConfigMerger.mergeWithDiagnostics(fileOpts, List("--y", "20"))
         assert(diag.conflicts)(isEmpty)
       },


### PR DESCRIPTION
Implement a robust dotfile configuration system for ZIO CLI that reads .<commandName> files from cwd up to root and home directory.

Changes:
- ConfigFileResolver: discovers dotfiles with priority ordering (cwd > parents > home)
- ConfigParser: parses --key=value and --flag formats from dotfiles
- ConfigMerger: deterministic merge engine (CLI args override file configs)
- ConfigDiagnostics: --config-diagnostics flag for provenance reporting
- Cross-platform: JVM/Native use java.nio.file, JS has no-op stub
- 21 comprehensive tests covering resolution, parsing, merging, diagnostics
- Help docs updated to explain dotfile configuration system

Follows existing PlatformSpecific pattern used by Compgen, Args, Options.