### PR TITLE
Fix --help/--wizard showing wrong subcommand help (#448) — review follow-up

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -118,13 +118,24 @@ object Command {
             .builtInOptions(self, self.synopsis, self.helpDoc)
           Options
             .validate(options, args.tail, conf)
-            .map(_._3)
-            .someOrFail(
-              ValidationError(
-                ValidationErrorType.NoBuiltInMatch,
-                HelpDoc.p(s"No built-in option was matched")
-              )
-            )
+            .flatMap { case (_, leftover, value) =>
+              if (leftover.nonEmpty)
+                ZIO.fail(
+                  ValidationError(
+                    ValidationErrorType.NoBuiltInMatch,
+                    HelpDoc.p(s"No built-in option was matched")
+                  )
+                )
+              else
+                ZIO
+                  .fromOption(value)
+                  .mapError(_ =>
+                    ValidationError(
+                      ValidationErrorType.NoBuiltInMatch,
+                      HelpDoc.p(s"No built-in option was matched")
+                    )
+                  )
+            }
             .map(CommandDirective.BuiltIn)
         } else
           ZIO.fail(
@@ -293,7 +304,7 @@ object Command {
           ZIO.fail(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty))
         else
           child
-            .parse(args.tail, conf)
+            .parse(args.tail, conf.copy(finalCheckBuiltIn = false))
             .collect(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty)) {
               case CommandDirective.BuiltIn(BuiltInOption.ShowHelp(synopsis, helpDoc)) =>
                 val parentName = names.headOption.getOrElse("")
@@ -313,7 +324,7 @@ object Command {
           ZIO.fail(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty))
         else
           child
-            .parse(args.tail, conf)
+            .parse(args.tail, conf.copy(finalCheckBuiltIn = false))
             .collect(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty)) {
               case directive @ CommandDirective.BuiltIn(BuiltInOption.ShowWizard(_)) => directive
             }

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -283,21 +283,23 @@ object Command {
       args: List[String],
       conf: CliConfig
     ): IO[ValidationError, CommandDirective[(A, B)]] = {
+      val childConf       = conf.copy(finalCheckBuiltIn = false)
+      def invalidArgument = ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty)
+
       val helpDirectiveForChild =
         if (args.isEmpty)
-          ZIO.fail(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty))
+          ZIO.fail(invalidArgument)
         else
           child
-            .parse(args.tail, conf.copy(finalCheckBuiltIn = false))
-            .collect(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty)) {
-              case CommandDirective.BuiltIn(BuiltInOption.ShowHelp(synopsis, helpDoc)) =>
-                val parentName = names.headOption.getOrElse("")
-                CommandDirective.builtIn {
-                  BuiltInOption.ShowHelp(
-                    UsageSynopsis.Named(List(parentName), None) + synopsis,
-                    helpDoc
-                  )
-                }
+            .parse(args.tail, childConf)
+            .collect(invalidArgument) { case CommandDirective.BuiltIn(BuiltInOption.ShowHelp(synopsis, helpDoc)) =>
+              val parentName = names.headOption.getOrElse("")
+              CommandDirective.builtIn {
+                BuiltInOption.ShowHelp(
+                  UsageSynopsis.Named(List(parentName), None) + synopsis,
+                  helpDoc
+                )
+              }
             }
 
       val helpDirectiveForParent =
@@ -305,12 +307,12 @@ object Command {
 
       val wizardDirectiveForChild =
         if (args.isEmpty)
-          ZIO.fail(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty))
+          ZIO.fail(invalidArgument)
         else
           child
-            .parse(args.tail, conf.copy(finalCheckBuiltIn = false))
-            .collect(ValidationError(ValidationErrorType.InvalidArgument, HelpDoc.empty)) {
-              case directive @ CommandDirective.BuiltIn(BuiltInOption.ShowWizard(_)) => directive
+            .parse(args.tail, childConf)
+            .collect(invalidArgument) { case directive @ CommandDirective.BuiltIn(BuiltInOption.ShowWizard(_)) =>
+              directive
             }
 
       val wizardDirectiveForParent =

--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -116,27 +116,11 @@ object Command {
         if (args.headOption.exists(conf.normalizeCase(_) == conf.normalizeCase(self.name))) {
           val options = BuiltInOption
             .builtInOptions(self, self.synopsis, self.helpDoc)
+          def noBuiltInMatch =
+            ValidationError(ValidationErrorType.NoBuiltInMatch, HelpDoc.p("No built-in option was matched"))
           Options
             .validate(options, args.tail, conf)
-            .flatMap { case (_, leftover, value) =>
-              if (leftover.nonEmpty)
-                ZIO.fail(
-                  ValidationError(
-                    ValidationErrorType.NoBuiltInMatch,
-                    HelpDoc.p(s"No built-in option was matched")
-                  )
-                )
-              else
-                ZIO
-                  .fromOption(value)
-                  .mapError(_ =>
-                    ValidationError(
-                      ValidationErrorType.NoBuiltInMatch,
-                      HelpDoc.p(s"No built-in option was matched")
-                    )
-                  )
-            }
-            .map(CommandDirective.BuiltIn)
+            .collect(noBuiltInMatch) { case (_, Nil, Some(value)) => CommandDirective.BuiltIn(value) }
         } else
           ZIO.fail(
             ValidationError(

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -363,6 +363,48 @@ object CommandSpec extends ZIOSpecDefault {
         }
       )
     },
+    suite("root-level --help with subcommands (issue #448)") {
+      val git =
+        Command("git", Options.Empty, Args.none).subcommands(
+          Command("add", Options.Empty, Args.none).subcommands(
+            Command("subsubCommand", Options.Empty, Args.none)
+          ),
+          Command("clone", Options.Empty, Args.none)
+        )
+
+      def helpText(result: CommandDirective[Any]): String = result match {
+        case CommandDirective.BuiltIn(ShowHelp(_, helpDoc)) => helpDoc.toPlaintext()
+        case _                                              => ""
+      }
+
+      Vector(
+        test("--help at root shows parent help, not child help") {
+          assertZIO(git.parse(List("git", "--help"), CliConfig.default).map(helpText))(
+            containsString("add") && containsString("clone")
+          )
+        },
+        test("-h at root shows parent help") {
+          assertZIO(git.parse(List("git", "-h"), CliConfig.default).map(helpText))(
+            containsString("add") && containsString("clone")
+          )
+        },
+        test("subcommand --help shows subcommand help") {
+          assertZIO(git.parse(List("git", "add", "--help"), CliConfig.default).map(helpText))(
+            containsString("subsubCommand")
+          )
+        },
+        test("empty args shows parent help") {
+          assertZIO(git.parse(List("git"), CliConfig.default).map(helpText))(
+            containsString("add") && containsString("clone")
+          )
+        },
+        test("--wizard at root shows parent wizard, not child wizard") {
+          assertZIO(git.parse(List("git", "--wizard"), CliConfig.default).map(directiveType))(
+            equalTo("wizard")
+          )
+        }
+      )
+    },
     test("cmd opts -- args") {
       val command =
         Command("cmd", Options.text("something").optional ++ Options.boolean("verbose").alias("v"), Args.text.*)

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -402,6 +402,18 @@ object CommandSpec extends ZIOSpecDefault {
           assertZIO(git.parse(List("git", "--wizard"), CliConfig.default).map(directiveType))(
             equalTo("wizard")
           )
+        },
+        test("--help is not consumed as built-in when extra args remain") {
+          val cmd = Command("cmd", Options.Empty, Args.text.*)
+          assertZIO(cmd.parse(List("cmd", "--help", "payload"), CliConfig.default).map(directiveType))(
+            equalTo("user")
+          )
+        },
+        test("--wizard is not consumed as built-in when extra args remain") {
+          val cmd = Command("cmd", Options.Empty, Args.text.*)
+          assertZIO(cmd.parse(List("cmd", "--wizard", "payload"), CliConfig.default).map(directiveType))(
+            equalTo("user")
+          )
         }
       )
     },


### PR DESCRIPTION
Continues #559 by @tjarvstrand. The original fix is unchanged; this PR adds the refactor requested in the review thread (https://github.com/zio/zio-cli/pull/559#discussion_r3142204327) plus closely-related cleanups, so credit for the fix stays with the original author.

## Commits

1. **`eb68646` (tjarvstrand)** — original fix for #448, unchanged.
2. **Consolidate `NoBuiltInMatch` error and cover leftover case** — addresses the review feedback on `parseBuiltInArgs`:
   - Replaces the new `if (leftover.nonEmpty) ... else ZIO.fromOption(value).mapError(...)` with `ZIO#collect(noBuiltInMatch) { case (_, Nil, Some(value)) => CommandDirective.BuiltIn(value) }`, matching the style already used in `Subcommands#parse`. Also folds the `.map(BuiltIn)` step into the partial function.
   - Drops the unnecessary `s` interpolator on the error message (per the original Copilot note).
   - Declares `noBuiltInMatch` as `def` rather than `val`. Both consumers (`ZIO#collect`'s `e: => E1` and `ZIO.fail`'s `error: => E`) take their failure by-name, so `def` defers allocation to the failure path while keeping the descriptive name.
   - Adds two regression tests for the consolidated `leftover.nonEmpty` branch (`cmd --help payload` and `cmd --wizard payload` must not be consumed as built-in directives). The `--help` variant was first verified RED on `master` (returned `"help"` instead of `"user"`) before being committed.
3. **Share `childConf` and `invalidArgument` in `Subcommands.parse`** — both `helpDirectiveForChild` and `wizardDirectiveForChild` constructed the same `conf.copy(finalCheckBuiltIn = false)` and the same `ValidationError(InvalidArgument, HelpDoc.empty)`. Hoisted to shared local definitions to keep the two branches in lockstep. `invalidArgument` is `def` for the same by-name reason as above; `childConf` stays `val` since `child.parse` takes its config strictly.

## Behavior

Pure refactor — no behavior change.

| Platform | Result |
| --- | --- |
| `zioCliJVM/testOnly zio.cli.CommandSpec` | 37/37 |
| `zioCliJS/testOnly zio.cli.CommandSpec` | 37/37 |
| `zioCliNative/testOnly zio.cli.CommandSpec` | 37/37 |
| `scalafmtCheckAll` | clean |

Closes #448 if merged.
