### PR TITLE
Fix --help on a non-first subcommand showing wrong help (#586)

### DIFF
--- a/zio-cli/shared/src/main/scala/zio/cli/Command.scala
+++ b/zio-cli/shared/src/main/scala/zio/cli/Command.scala
@@ -328,7 +328,7 @@ object Command {
           case builtIn @ CommandDirective.BuiltIn(_)                          => ZIO.succeed(builtIn)
           case CommandDirective.UserDefined(leftover, a) if leftover.nonEmpty =>
             child
-              .parse(leftover, conf)
+              .parse(leftover, childConf)
               .mapBoth(
                 {
                   case ValidationError(CommandMismatch, _) =>

--- a/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
+++ b/zio-cli/shared/src/test/scala/zio/cli/CommandSpec.scala
@@ -393,6 +393,15 @@ object CommandSpec extends ZIOSpecDefault {
             containsString("subsubCommand")
           )
         },
+        test("non-first subcommand --help shows that subcommand's help, not the first (issue #586)") {
+          val tool = Command("tool", Options.Empty, Args.none).subcommands(
+            Command("start", Options.text("port")).withHelp("start the server").map(_ => ()),
+            Command("stop", Options.Empty, Args.none).withHelp("stop the server")
+          )
+          assertZIO(tool.parse(List("tool", "stop", "--help"), CliConfig.default).map(helpText))(
+            containsString("stop the server") && not(containsString("port"))
+          )
+        },
         test("empty args shows parent help") {
           assertZIO(git.parse(List("git"), CliConfig.default).map(helpText))(
             containsString("add") && containsString("clone")


### PR DESCRIPTION
Closes #586.

## Problem
`root <sub> --help` showed the **first** registered subcommand's help instead of the named one, for every non-first subcommand (and nested cases). Root `--help` was fine.

## Fix
`Subcommands.parse` parsed the child `OrElse` with the original `conf` (`finalCheckBuiltIn = true`) in the `UserDefined` branch. A non-matching alternative then ran `exhaustiveSearch`, returned its *own* help as a success, and short-circuited the `OrElse` before the named subcommand was tried. Switched that one call to the existing `childConf` (`finalCheckBuiltIn = false`) — already used in the sibling help/wizard paths in the same method — so a mismatch fails as `CommandMismatch` and `OrElse` advances to the correct subcommand.

## Test
Added a regression test under the `issue #448` suite: `tool stop --help` must show `stop`'s help and not the first subcommand's. Verified RED on `master` (leaked the first subcommand's option) before the fix.

| Platform | Result |
| --- | --- |
| `zioCliJVM/testOnly zio.cli.CommandSpec` | 38/38 |
| `zioCliJS/testOnly zio.cli.CommandSpec` | 38/38 |
| `zioCliNative/testOnly zio.cli.CommandSpec` | 38/38 |
| `sbt fmt` / `sbt check` | clean |
